### PR TITLE
Population model data structure and XML

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,88 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: false
+AlignOperands: true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      true
+  AfterControlStatement: false
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories:
+  - Regex:           '^\<[^Q][^/.>]*\>'
+    Priority:        -2
+  - Regex:           '^\<'
+    Priority:        -1
+  - Regex:           '^\"'
+    Priority:        0
+IndentCaseLabels: false
+IndentWidth:     8
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 150
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        8
+UseTab:          Always
+...

--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -36,6 +36,7 @@ set(LIB_SRC
 #---	
     pop/Person.cpp
     pop/PopulationBuilder.cpp
+    pop/PopulationModel.cpp
 #---
 	sim/run_stride.cpp
 	sim/Simulator.cpp

--- a/src/main/cpp/pop/PopulationBuilder.cpp
+++ b/src/main/cpp/pop/PopulationBuilder.cpp
@@ -123,10 +123,11 @@ shared_ptr<Population> PopulationBuilder::Build(
                 using boost::property_tree::ptree;
                 ptree pt;
                 read_xml(pop_file, pt);
-                PopulationModel model{ pt };
+                population_model::Model model;
+                model.parse(pt);
 
                 // Example:
-                std::cout << "child_maximum_age_gap: " << model.child_maximum_age_gap << std::endl;
+                std::cout << "child_maximum_age_gap: " << model.family.age_gap.child.maximum << std::endl;
                 // TODO: generate `population` from `model`.
 
         } else {

--- a/src/main/cpp/pop/PopulationModel.cpp
+++ b/src/main/cpp/pop/PopulationModel.cpp
@@ -1,0 +1,9 @@
+#include "PopulationModel.h"
+
+namespace stride {
+
+PopulationModel::PopulationModel(const boost::property_tree::ptree& pt) {
+	maximum_age = pt.get<int>("popgen.age.maximum");
+}
+
+}

--- a/src/main/cpp/pop/PopulationModel.cpp
+++ b/src/main/cpp/pop/PopulationModel.cpp
@@ -1,9 +1,45 @@
 #include "PopulationModel.h"
+#include <iostream>
 
 namespace stride {
 
 PopulationModel::PopulationModel(const boost::property_tree::ptree& pt) {
 	maximum_age = pt.get<int>("popgen.age.maximum");
+	elbow_age = pt.get<int>("popgen.age.elbow");
+
+	live_alone_minimum_age = pt.get<int>("popgen.family.age.live_alone_minimum");
+	child_maximum_age = pt.get<int>("popgen.family.age.child_maximum");
+	parent_minimum_age = pt.get<int>("popgen.family.age.parent_minimum");
+	parent_maximum_age = pt.get<int>("popgen.family.age.parent_maximum");
+	child_parent_minimum_age_gap = pt.get<int>("popgen.family.age_gap.child_parent_minimum");
+	parent_minimum_age_gap = pt.get<int>("popgen.family.age_gap.parent_minimum");
+	parent_maximum_age_gap = pt.get<int>("popgen.family.age_gap.parent_maximum");
+	child_minimum_age_gap = pt.get<int>("popgen.family.age_gap.child_minimum");
+	child_maximum_age_gap = pt.get<int>("popgen.family.age_gap.child_maximum");
+
+	for (const auto &i : pt.get_child("popgen.family.size_distribution")) {
+		if (i.first == "p") {
+			family_size_distribution.emplace_back(i.second.get_value<int>());
+		}
+	}
+
+	kindergarten_age = pt.get<int>("popgen.school.age.kindergarten");
+	primary_school_age = pt.get<int>("popgen.school.age.primary_school");
+	secondary_school_age = pt.get<int>("popgen.school.age.secondary_school");
+	higher_eduation_age = pt.get<int>("popgen.school.age.higher_education");
+	graduation_age = pt.get<int>("popgen.school.age.graduation");
+	p_higher_education = pt.get<double>("popgen.school.p_higher_education");
+	school_minimum_size = pt.get<int>("popgen.school.size.minimum");
+	school_maximum_size = pt.get<int>("popgen.school.size.maximum");
+
+	work_minimum_age = pt.get<int>("popgen.work.age.minimum");
+	work_maximum_age = pt.get<int>("popgen.work.age.maximum");
+	p_employed = pt.get<double>("popgen.work.p_employed");
+	work_minimum_size = pt.get<int>("popgen.work.size.minimum");
+	work_maximum_size = pt.get<int>("popgen.work.size.maximum");
+
+	community_minimum_size = pt.get<int>("popgen.community.size.minimum");
+	community_maximum_size = pt.get<int>("popgen.community.size.maximum");
 }
 
 }

--- a/src/main/cpp/pop/PopulationModel.cpp
+++ b/src/main/cpp/pop/PopulationModel.cpp
@@ -2,44 +2,76 @@
 #include <iostream>
 
 namespace stride {
+namespace population_model {
 
-PopulationModel::PopulationModel(const boost::property_tree::ptree& pt) {
-	maximum_age = pt.get<int>("popgen.age.maximum");
-	elbow_age = pt.get<int>("popgen.age.elbow");
+void Age::parse(const boost::property_tree::ptree& pt) {
+	maximum = pt.get<int>("maximum");
+	elbow = pt.get<int>("elbow");
+}
 
-	live_alone_minimum_age = pt.get<int>("popgen.family.age.live_alone_minimum");
-	child_maximum_age = pt.get<int>("popgen.family.age.child_maximum");
-	parent_minimum_age = pt.get<int>("popgen.family.age.parent_minimum");
-	parent_maximum_age = pt.get<int>("popgen.family.age.parent_maximum");
-	child_parent_minimum_age_gap = pt.get<int>("popgen.family.age_gap.child_parent_minimum");
-	parent_minimum_age_gap = pt.get<int>("popgen.family.age_gap.parent_minimum");
-	parent_maximum_age_gap = pt.get<int>("popgen.family.age_gap.parent_maximum");
-	child_minimum_age_gap = pt.get<int>("popgen.family.age_gap.child_minimum");
-	child_maximum_age_gap = pt.get<int>("popgen.family.age_gap.child_maximum");
+void FamilyAge::parse(const boost::property_tree::ptree& pt) {
+	live_alone_minimum = pt.get<int>("live_alone_minimum");
+	child_maximum = pt.get<int>("child_maximum");
+	parent.parse(pt.get_child("parent"));
+}
 
-	for (const auto &i : pt.get_child("popgen.family.size_distribution")) {
+void FamilyAgeGap::parse(const boost::property_tree::ptree& pt) {
+	child_parent_minimum = pt.get<int>("child_parent_minimum");
+	parent.parse(pt.get_child("parent"));
+	child.parse(pt.get_child("child"));
+}
+
+void Family::parse(const boost::property_tree::ptree& pt) {
+	age.parse(pt.get_child("age"));
+	age_gap.parse(pt.get_child("age_gap"));
+
+	// XML doesn't really have lists, so this is stored kinda hackily:
+	//
+	//     <size_distribution>
+	//         <p>12</p> <p>27</p> <p>20</p> ...
+	//     </size_distribution
+	//
+	for (const auto &i : pt.get_child("size_distribution")) {
 		if (i.first == "p") {
-			family_size_distribution.emplace_back(i.second.get_value<int>());
+			size_distribution.emplace_back(i.second.get_value<int>());
 		}
 	}
-
-	kindergarten_age = pt.get<int>("popgen.school.age.kindergarten");
-	primary_school_age = pt.get<int>("popgen.school.age.primary_school");
-	secondary_school_age = pt.get<int>("popgen.school.age.secondary_school");
-	higher_eduation_age = pt.get<int>("popgen.school.age.higher_education");
-	graduation_age = pt.get<int>("popgen.school.age.graduation");
-	p_higher_education = pt.get<double>("popgen.school.p_higher_education");
-	school_minimum_size = pt.get<int>("popgen.school.size.minimum");
-	school_maximum_size = pt.get<int>("popgen.school.size.maximum");
-
-	work_minimum_age = pt.get<int>("popgen.work.age.minimum");
-	work_maximum_age = pt.get<int>("popgen.work.age.maximum");
-	p_employed = pt.get<double>("popgen.work.p_employed");
-	work_minimum_size = pt.get<int>("popgen.work.size.minimum");
-	work_maximum_size = pt.get<int>("popgen.work.size.maximum");
-
-	community_minimum_size = pt.get<int>("popgen.community.size.minimum");
-	community_maximum_size = pt.get<int>("popgen.community.size.maximum");
 }
 
+void SchoolAge::parse(const boost::property_tree::ptree& pt) {
+	kindergarten = pt.get<int>("kindergarten");
+	primary_school = pt.get<int>("primary_school");
+	secondary_school = pt.get<int>("secondary_school");
+	higher_eduation = pt.get<int>("higher_education");
+	graduation = pt.get<int>("graduation");
 }
+
+void School::parse(const boost::property_tree::ptree& pt) {
+	age.parse(pt.get_child("age"));
+	p_higher_education = pt.get<double>("p_higher_education");
+	size.parse(pt.get_child("size"));
+}
+
+void Work::parse(const boost::property_tree::ptree& pt) {
+	age.parse(pt.get_child("age"));
+	p_employed = pt.get<double>("p_employed");
+	size.parse(pt.get_child("size"));
+}
+
+void Community::parse(const boost::property_tree::ptree& pt) {
+	size.parse(pt.get_child("size"));
+}
+
+void Model::parse(const boost::property_tree::ptree& pt) {
+	auto root = pt.get_child("population_model");
+
+	age.parse(root.get_child("age"));
+	family.parse(root.get_child("family"));
+	school.parse(root.get_child("school"));
+	work.parse(root.get_child("work"));
+	community.parse(root.get_child("community"));
+	size.parse(root.get_child("size"));
+}
+
+} // namespace population_model
+} // namespace stride

--- a/src/main/cpp/pop/PopulationModel.cpp
+++ b/src/main/cpp/pop/PopulationModel.cpp
@@ -1,27 +1,31 @@
-#include "PopulationModel.h"
 #include <iostream>
+#include "PopulationModel.h"
 
 namespace stride {
 namespace population_model {
 
-void Age::parse(const boost::property_tree::ptree& pt) {
+void Age::parse(const boost::property_tree::ptree& pt)
+{
 	maximum = pt.get<int>("maximum");
 	elbow = pt.get<int>("elbow");
 }
 
-void FamilyAge::parse(const boost::property_tree::ptree& pt) {
+void FamilyAge::parse(const boost::property_tree::ptree& pt)
+{
 	live_alone_minimum = pt.get<int>("live_alone_minimum");
 	child_maximum = pt.get<int>("child_maximum");
 	parent.parse(pt.get_child("parent"));
 }
 
-void FamilyAgeGap::parse(const boost::property_tree::ptree& pt) {
+void FamilyAgeGap::parse(const boost::property_tree::ptree& pt)
+{
 	child_parent_minimum = pt.get<int>("child_parent_minimum");
 	parent.parse(pt.get_child("parent"));
 	child.parse(pt.get_child("child"));
 }
 
-void Family::parse(const boost::property_tree::ptree& pt) {
+void Family::parse(const boost::property_tree::ptree& pt)
+{
 	age.parse(pt.get_child("age"));
 	age_gap.parse(pt.get_child("age_gap"));
 
@@ -31,14 +35,15 @@ void Family::parse(const boost::property_tree::ptree& pt) {
 	//         <p>12</p> <p>27</p> <p>20</p> ...
 	//     </size_distribution
 	//
-	for (const auto &i : pt.get_child("size_distribution")) {
+	for (const auto& i : pt.get_child("size_distribution")) {
 		if (i.first == "p") {
 			size_distribution.emplace_back(i.second.get_value<int>());
 		}
 	}
 }
 
-void SchoolAge::parse(const boost::property_tree::ptree& pt) {
+void SchoolAge::parse(const boost::property_tree::ptree& pt)
+{
 	kindergarten = pt.get<int>("kindergarten");
 	primary_school = pt.get<int>("primary_school");
 	secondary_school = pt.get<int>("secondary_school");
@@ -46,23 +51,27 @@ void SchoolAge::parse(const boost::property_tree::ptree& pt) {
 	graduation = pt.get<int>("graduation");
 }
 
-void School::parse(const boost::property_tree::ptree& pt) {
+void School::parse(const boost::property_tree::ptree& pt)
+{
 	age.parse(pt.get_child("age"));
 	p_higher_education = pt.get<double>("p_higher_education");
 	size.parse(pt.get_child("size"));
 }
 
-void Work::parse(const boost::property_tree::ptree& pt) {
+void Work::parse(const boost::property_tree::ptree& pt)
+{
 	age.parse(pt.get_child("age"));
 	p_employed = pt.get<double>("p_employed");
 	size.parse(pt.get_child("size"));
 }
 
-void Community::parse(const boost::property_tree::ptree& pt) {
+void Community::parse(const boost::property_tree::ptree& pt)
+{
 	size.parse(pt.get_child("size"));
 }
 
-void Model::parse(const boost::property_tree::ptree& pt) {
+void Model::parse(const boost::property_tree::ptree& pt)
+{
 	auto root = pt.get_child("population_model");
 
 	age.parse(root.get_child("age"));

--- a/src/main/cpp/pop/PopulationModel.h
+++ b/src/main/cpp/pop/PopulationModel.h
@@ -10,106 +10,167 @@
 #include <boost/property_tree/ptree.hpp>
 
 namespace stride {
+namespace population_model {
 
-/**
- * Data from which populations may be generated.
- */
-struct PopulationModel
+template <typename T>
+struct InclusiveRange
 {
-	PopulationModel(const boost::property_tree::ptree& pt);
+	// Parse an inclusive range from a ptree with "minimum" and "maximum" keys.
+	// Throws `boost::property_tree::ptree_error` on invalid inputs.
+	void parse(const boost::property_tree::ptree& pt);
+	T minimum;
+	T maximum;
+};
 
-	/////////////////////////////////////////////////////////////////
-	// Age parameters
-	/////////////////////////////////////////////////////////////////
+template <typename T>
+void InclusiveRange<T>::parse(const boost::property_tree::ptree& pt) {
+	minimum = pt.get<T>("minimum");
+	maximum = pt.get<T>("maximum");
+}
+
+struct Age
+{
+	// Read the age model values from a ptree.
+	// Throws `boost::property_tree::ptree_error` on invalid inputs.
+	void parse(const boost::property_tree::ptree& pt);
 
 	// The age distribution is a piecewise linear curve connecting
 	// (0, h), (elbow_age, h), and (maximum_age, 0), where h is computed
 	// so that the area under the curve is 1.
-	int maximum_age;
-	int elbow_age;
+	int maximum;
+	int elbow;
+};
 
-	/////////////////////////////////////////////////////////////////
-	// Family parameters
-	/////////////////////////////////////////////////////////////////
+struct FamilyAge{
+
+	// Read the family age model values from a ptree.
+	// Throws `boost::property_tree::ptree_error` on invalid inputs.
+	void parse(const boost::property_tree::ptree& pt);
 
 	// Minimum age for members of families of size <= 2.
-	int live_alone_minimum_age;
+	int live_alone_minimum;
 
 	// Maximum age for children in families of size >= 3.
-	int child_maximum_age;
+	int child_maximum;
 
-	// Minimum age for parents, in families of size >= 3.
-	int parent_minimum_age;
+	// Age range for parents, in families of size >= 3.
+	InclusiveRange<int> parent;
+};
 
-	// Maximum age for parents, in families of size >= 3.
-	int parent_maximum_age;
+struct FamilyAgeGap{
+
+	// Read the family age gap model values from a ptree.
+	// Throws `boost::property_tree::ptree_error` on invalid inputs.
+	void parse(const boost::property_tree::ptree& pt);
 
 	// Minimum age gap between children and parents.
-	int child_parent_minimum_age_gap;
+	int child_parent_minimum;
 
 	// Inter-parent age gap range.
-	int parent_minimum_age_gap;
-	int parent_maximum_age_gap;
+	InclusiveRange<int> parent;
 
 	// Inter-child age gap range.
-	int child_minimum_age_gap;
-	int child_maximum_age_gap;
+	InclusiveRange<int> child;
+};
+
+struct Family
+{
+	// Read the family model values from a ptree.
+	// Throws `boost::property_tree::ptree_error` on invalid inputs.
+	void parse(const boost::property_tree::ptree& pt);
+
+	FamilyAge age;
+	FamilyAgeGap age_gap;
 
 	// Family size probabilities (relative to sum of vector).
-	// family_size_distribution[k] is the relative probability
-	// of a family having (k + 1) members.
-	std::vector<int> family_size_distribution;
+	// size_distribution[k] is the relative probability of a family having (k + 1) members.
+	std::vector<int> size_distribution;
+};
 
-	/////////////////////////////////////////////////////////////////
-	// School parameters
-	/////////////////////////////////////////////////////////////////
+struct SchoolAge
+{
+	// Read the school age model values from a ptree.
+	// Throws `boost::property_tree::ptree_error` on invalid inputs.
+	void parse(const boost::property_tree::ptree& pt);
 
 	// The age at which people start going to kindergarten.
-	int kindergarten_age;
+	int kindergarten;
 
 	// The age at which people start going to primary school.
-	int primary_school_age;
+	int primary_school;
 
 	// The age at which people start going to secondary school.
-	int secondary_school_age;
+	int secondary_school;
 
 	// The age at which people start higher education (or leave school).
-	int higher_eduation_age;
+	int higher_eduation;
 
 	// The age at which people graduate from higher education.
-	int graduation_age;
+	int graduation;
+};
+
+struct School
+{
+	// Read the school model values from a ptree.
+	// Throws `boost::property_tree::ptree_error` on invalid inputs.
+	void parse(const boost::property_tree::ptree& pt);
+
+	SchoolAge age;
 
 	// The percentage of people who go into higher education.
 	double p_higher_education;
 
 	// The size range for schools (in # of students).
-	int school_minimum_size;
-	int school_maximum_size;
+	InclusiveRange<int> size;
+};
 
-	/////////////////////////////////////////////////////////////////
-	// Work parameters
-	/////////////////////////////////////////////////////////////////
+struct Work
+{
+	// Read the work model values from a ptree.
+	// Throws `boost::property_tree::ptree_error` on invalid inputs.
+	void parse(const boost::property_tree::ptree& pt);
 
 	// The age range for employees.
-	int work_minimum_age;
-	int work_maximum_age;
+	InclusiveRange<int> age;
 
 	// The percentage of people, within this age range, that is employed.
 	double p_employed;
 
 	// The size range for work sites (in # of employees). The distribution is linear.
-	int work_minimum_size;
-	int work_maximum_size;
-
-	/////////////////////////////////////////////////////////////////
-	// Community parameters
-	/////////////////////////////////////////////////////////////////
-
-	// The size range for communities (in # of members). The distribution is linear.
-	int community_minimum_size;
-	int community_maximum_size;
+	InclusiveRange<int> size;
 };
 
-}
+struct Community
+{
+	// Read the community model values from a ptree.
+	// Throws `boost::property_tree::ptree_error` on invalid inputs.
+	void parse(const boost::property_tree::ptree& pt);
+
+	// The size range for communities (in # of members). The distribution is linear.
+	InclusiveRange<int> size;
+};
+
+/**
+ * Data from which populations may be generated.
+ */
+struct Model
+{
+	// Read a population model from an ptree.
+	// Throws `boost::property_tree::ptree_error` on invalid inputs.
+	// See data/population_model_default.xml for the structure `pt` should have.
+	void parse(const boost::property_tree::ptree& pt);
+
+	Age age;
+	Family family;
+	School school;
+	Work work;
+	Community community;
+
+	// Size range for the entire population.
+	InclusiveRange<int> size;
+};
+
+} // namespace population_model
+} // namespace stride
 
 #endif

--- a/src/main/cpp/pop/PopulationModel.h
+++ b/src/main/cpp/pop/PopulationModel.h
@@ -16,98 +16,98 @@ namespace stride {
  */
 struct PopulationModel
 {
-    PopulationModel(const boost::property_tree::ptree& pt);
+	PopulationModel(const boost::property_tree::ptree& pt);
 
-    /////////////////////////////////////////////////////////////////
-    // Age parameters
-    /////////////////////////////////////////////////////////////////
+	/////////////////////////////////////////////////////////////////
+	// Age parameters
+	/////////////////////////////////////////////////////////////////
 
-    // The age distribution is a piecewise linear curve connecting
-    // (0, h), (elbow_age, h), and (maximum_age, 0), where h is computed
-    // so that the area under the curve is 1.
-    int maximum_age;
-    int elbow_age;
+	// The age distribution is a piecewise linear curve connecting
+	// (0, h), (elbow_age, h), and (maximum_age, 0), where h is computed
+	// so that the area under the curve is 1.
+	int maximum_age;
+	int elbow_age;
 
-    /////////////////////////////////////////////////////////////////
-    // Family parameters
-    /////////////////////////////////////////////////////////////////
+	/////////////////////////////////////////////////////////////////
+	// Family parameters
+	/////////////////////////////////////////////////////////////////
 
-    // Minimum age for members of families of size <= 2.
-    int live_alone_minimum_age;
+	// Minimum age for members of families of size <= 2.
+	int live_alone_minimum_age;
 
-    // Maximum age for children in families of size >= 3.
-    int child_maximum_age;
+	// Maximum age for children in families of size >= 3.
+	int child_maximum_age;
 
-    // Minimum age for parents, in families of size >= 3.
-    int parent_minimum_age;
+	// Minimum age for parents, in families of size >= 3.
+	int parent_minimum_age;
 
-    // Maximum age for parents, in families of size >= 3.
-    int parent_maximum_age;
+	// Maximum age for parents, in families of size >= 3.
+	int parent_maximum_age;
 
-    // Minimum age gap between children and parents.
-    int child_parent_minimum_age_gap;
+	// Minimum age gap between children and parents.
+	int child_parent_minimum_age_gap;
 
-    // Inter-parent age gap range.
-    int parent_minimum_age_gap;
-    int parent_maximum_age_gap;
+	// Inter-parent age gap range.
+	int parent_minimum_age_gap;
+	int parent_maximum_age_gap;
 
-    // Inter-child age gap range.
-    int child_minimum_age_gap;
-    int child_maximum_age_gap;
+	// Inter-child age gap range.
+	int child_minimum_age_gap;
+	int child_maximum_age_gap;
 
-    // Family size probabilities (relative to sum of vector).
-    // family_size_distribution[k] is the relative probability
-    // of a family having (k + 1) members.
-    std::vector<int> size_distribution;
+	// Family size probabilities (relative to sum of vector).
+	// family_size_distribution[k] is the relative probability
+	// of a family having (k + 1) members.
+	std::vector<int> family_size_distribution;
 
-    /////////////////////////////////////////////////////////////////
-    // School parameters
-    /////////////////////////////////////////////////////////////////
+	/////////////////////////////////////////////////////////////////
+	// School parameters
+	/////////////////////////////////////////////////////////////////
 
-    // The age at which people start going to kindergarten.
-    int kindergarten_age;
+	// The age at which people start going to kindergarten.
+	int kindergarten_age;
 
-    // The age at which people start going to primary school.
-    int primary_school_age;
+	// The age at which people start going to primary school.
+	int primary_school_age;
 
-    // The age at which people start going to secondary school.
-    int secondary_school_age;
+	// The age at which people start going to secondary school.
+	int secondary_school_age;
 
-    // The age at which people start higher education (or leave school).
-    int higher_eduation_age;
+	// The age at which people start higher education (or leave school).
+	int higher_eduation_age;
 
-    // The age at which people graduate from higher education.
-    int graduation_age;
+	// The age at which people graduate from higher education.
+	int graduation_age;
 
-    // The percentage of people who go into higher education.
-    double p_higher_education;
+	// The percentage of people who go into higher education.
+	double p_higher_education;
 
-    // The size range for schools (in # of students).
-    int school_minimum_size;
-    int school_maximum_size;
+	// The size range for schools (in # of students).
+	int school_minimum_size;
+	int school_maximum_size;
 
-    /////////////////////////////////////////////////////////////////
-    // Work parameters
-    /////////////////////////////////////////////////////////////////
+	/////////////////////////////////////////////////////////////////
+	// Work parameters
+	/////////////////////////////////////////////////////////////////
 
-    // The age range for employees.
-    int work_minimum_age;
-    int work_maximum_age;
+	// The age range for employees.
+	int work_minimum_age;
+	int work_maximum_age;
 
-    // The percentage of people, within this age range, that is employed.
-    double p_employed;
+	// The percentage of people, within this age range, that is employed.
+	double p_employed;
 
-    // The size range for work sites (in # of employees). The distribution is linear.
-    int work_minimum_size;
-    int work_maximum_size;
+	// The size range for work sites (in # of employees). The distribution is linear.
+	int work_minimum_size;
+	int work_maximum_size;
 
-    /////////////////////////////////////////////////////////////////
-    // Community parameters
-    /////////////////////////////////////////////////////////////////
+	/////////////////////////////////////////////////////////////////
+	// Community parameters
+	/////////////////////////////////////////////////////////////////
 
-    // The size range for communities (in # of members). The distribution is linear.
-    int community_minimum_size;
-    int community_maximum_size;
+	// The size range for communities (in # of members). The distribution is linear.
+	int community_minimum_size;
+	int community_maximum_size;
 };
 
 }

--- a/src/main/cpp/pop/PopulationModel.h
+++ b/src/main/cpp/pop/PopulationModel.h
@@ -23,7 +23,8 @@ struct InclusiveRange
 };
 
 template <typename T>
-void InclusiveRange<T>::parse(const boost::property_tree::ptree& pt) {
+void InclusiveRange<T>::parse(const boost::property_tree::ptree& pt)
+{
 	minimum = pt.get<T>("minimum");
 	maximum = pt.get<T>("maximum");
 }
@@ -41,8 +42,8 @@ struct Age
 	int elbow;
 };
 
-struct FamilyAge{
-
+struct FamilyAge
+{
 	// Read the family age model values from a ptree.
 	// Throws `boost::property_tree::ptree_error` on invalid inputs.
 	void parse(const boost::property_tree::ptree& pt);
@@ -57,8 +58,8 @@ struct FamilyAge{
 	InclusiveRange<int> parent;
 };
 
-struct FamilyAgeGap{
-
+struct FamilyAgeGap
+{
 	// Read the family age gap model values from a ptree.
 	// Throws `boost::property_tree::ptree_error` on invalid inputs.
 	void parse(const boost::property_tree::ptree& pt);

--- a/src/main/cpp/pop/PopulationModel.h
+++ b/src/main/cpp/pop/PopulationModel.h
@@ -1,0 +1,115 @@
+#ifndef POPULATION_MODEL_H_INCLUDED
+#define POPULATION_MODEL_H_INCLUDED
+
+/**
+ * @file
+ * Header file for the population model class
+ */
+
+#include <vector>
+#include <boost/property_tree/ptree.hpp>
+
+namespace stride {
+
+/**
+ * Data from which populations may be generated.
+ */
+struct PopulationModel
+{
+    PopulationModel(const boost::property_tree::ptree& pt);
+
+    /////////////////////////////////////////////////////////////////
+    // Age parameters
+    /////////////////////////////////////////////////////////////////
+
+    // The age distribution is a piecewise linear curve connecting
+    // (0, h), (elbow_age, h), and (maximum_age, 0), where h is computed
+    // so that the area under the curve is 1.
+    int maximum_age;
+    int elbow_age;
+
+    /////////////////////////////////////////////////////////////////
+    // Family parameters
+    /////////////////////////////////////////////////////////////////
+
+    // Minimum age for members of families of size <= 2.
+    int live_alone_minimum_age;
+
+    // Maximum age for children in families of size >= 3.
+    int child_maximum_age;
+
+    // Minimum age for parents, in families of size >= 3.
+    int parent_minimum_age;
+
+    // Maximum age for parents, in families of size >= 3.
+    int parent_maximum_age;
+
+    // Minimum age gap between children and parents.
+    int child_parent_minimum_age_gap;
+
+    // Inter-parent age gap range.
+    int parent_minimum_age_gap;
+    int parent_maximum_age_gap;
+
+    // Inter-child age gap range.
+    int child_minimum_age_gap;
+    int child_maximum_age_gap;
+
+    // Family size probabilities (relative to sum of vector).
+    // family_size_distribution[k] is the relative probability
+    // of a family having (k + 1) members.
+    std::vector<int> size_distribution;
+
+    /////////////////////////////////////////////////////////////////
+    // School parameters
+    /////////////////////////////////////////////////////////////////
+
+    // The age at which people start going to kindergarten.
+    int kindergarten_age;
+
+    // The age at which people start going to primary school.
+    int primary_school_age;
+
+    // The age at which people start going to secondary school.
+    int secondary_school_age;
+
+    // The age at which people start higher education (or leave school).
+    int higher_eduation_age;
+
+    // The age at which people graduate from higher education.
+    int graduation_age;
+
+    // The percentage of people who go into higher education.
+    double p_higher_education;
+
+    // The size range for schools (in # of students).
+    int school_minimum_size;
+    int school_maximum_size;
+
+    /////////////////////////////////////////////////////////////////
+    // Work parameters
+    /////////////////////////////////////////////////////////////////
+
+    // The age range for employees.
+    int work_minimum_age;
+    int work_maximum_age;
+
+    // The percentage of people, within this age range, that is employed.
+    double p_employed;
+
+    // The size range for work sites (in # of employees). The distribution is linear.
+    int work_minimum_size;
+    int work_maximum_size;
+
+    /////////////////////////////////////////////////////////////////
+    // Community parameters
+    /////////////////////////////////////////////////////////////////
+
+    // The size range for communities (in # of members). The distribution is linear.
+    int community_minimum_size;
+    int community_maximum_size;
+};
+
+}
+
+#endif

--- a/src/main/resources/config/run_test_popgen.xml
+++ b/src/main/resources/config/run_test_popgen.xml
@@ -4,7 +4,7 @@
     <r0>11</r0>
     <seeding_rate>0.002</seeding_rate>
     <immunity_rate>0.8</immunity_rate>
-    <population_file>popgen_default.xml</population_file>
+    <population_file>population_model_default.xml</population_file>
     <num_days>50</num_days>
     <output_prefix></output_prefix>
     <disease_config_file>disease_measles.xml</disease_config_file>

--- a/src/main/resources/config/run_test_popgen.xml
+++ b/src/main/resources/config/run_test_popgen.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<run>
+    <rng_seed>1</rng_seed>
+    <r0>11</r0>
+    <seeding_rate>0.002</seeding_rate>
+    <immunity_rate>0.8</immunity_rate>
+    <population_file>popgen_default.xml</population_file>
+    <num_days>50</num_days>
+    <output_prefix></output_prefix>
+    <disease_config_file>disease_measles.xml</disease_config_file>
+    <generate_person_file>1</generate_person_file>
+    <num_participants_survey>10</num_participants_survey>
+    <start_date>2017-01-01</start_date>
+    <holidays_file>holidays_none.json</holidays_file>
+    <age_contact_matrix_file>contact_matrix_average.xml</age_contact_matrix_file>
+    <log_level>Transmissions</log_level>
+</run>

--- a/src/main/resources/data/popgen_default.xml
+++ b/src/main/resources/data/popgen_default.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<popgen>
+    <age>
+        <!--
+          The age distribution is a piecewise linear curve connecting
+          (0, h), (elbow_age, h), and (maximum_age, 0), where h is computed
+          so that the area under the curve is 1.
+        -->
+        <maximum>95</maximum>
+        <elbow>65</elbow>
+    </age>
+    <family>
+        <age>
+            <!-- Minimum age for members of families of size <= 2. -->
+            <live_alone_minimum>18</live_alone_minimum>
+
+            <!-- Maximum age for children in families of size >= 3. -->
+            <child_maximum>23</child_maximum>
+
+            <!-- Minimum age for parents, in families of size >= 3. -->
+            <parent_minimum>20</parent_minimum>
+
+            <!-- Maximum age for parents, in families of size >= 3. -->
+            <parent_maximum>50</parent_maximum>
+        </age>
+        <age_gap>
+            <!-- Minimum age gap between children and parents. -->
+            <child_parent_minimum>18</child_parent_minimum>
+
+            <!-- Inter-parent age gap range. -->
+            <parent_minimum>0</parent_minimum>
+            <parent_maximum>5</parent_maximum>
+
+            <!-- Inter-child age gap range. -->
+            <child_minimum>1</child_minimum>
+            <child_maximum>10</child_maximum>
+        </age_gap>
+        <size_distribution>
+            <p>12</p> <!-- 1 member  -->
+            <p>27</p> <!-- 2 members -->
+            <p>20</p> <!-- 3 members -->
+            <p>22</p> <!-- 4 members -->
+            <p>10</p> <!-- 5 members -->
+            <p>9</p>  <!-- 6 members -->
+        </size_distribution>
+    </family>
+    <school>
+        <age>
+            <!-- The age at which people start going to kindergarten. -->
+            <kindergarten>3</kindergarten>
+
+            <!-- The age at which people start going to primary school. -->
+            <primary_school>7</primary_school>
+
+            <!-- The age at which people start going to secondary school. -->
+            <secondary_school>13</secondary_school>
+
+            <!-- The age at which people start higher education (or leave school). -->
+            <higher_education>19</higher_education>
+
+            <!-- The age at which people graduate from higher education. -->
+            <graduation>24</graduation>
+        </age>
+
+        <!-- The percentage of people who go into higher education. -->
+        <p_higher_education>0.25</p_higher_education>
+
+        <!-- The size range for schools (in # of students). The distribution is linear. -->
+        <size>
+            <!-- "approximately 500" -->
+            <minimum>450</minimum>
+            <maximum>550</maximum>
+        </size>
+    </school>
+    <work>
+        <!-- The age range for employees. -->
+        <age>
+            <minimum>18</minimum>
+            <maximum>65</maximum>
+        </age>
+
+        <!-- The percentage of people, within this age range, that is employed. -->
+        <p_employed>0.70</p_employed>
+
+        <!-- The size range for work sites (in # of employees). The distribution is linear. -->
+        <size>
+            <minimum>1</minimum>
+            <maximum>25</maximum>
+        </size>
+    </work>
+    <community>
+        <!-- The size range for communities (in # of members). The distribution is linear. -->
+        <size>
+            <!-- "approximately 2000" -->
+            <minimum>1800</minimum>
+            <maximum>2200</maximum>
+        </size>
+    </community>
+</popgen>

--- a/src/main/resources/data/population_model_default.xml
+++ b/src/main/resources/data/population_model_default.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<popgen>
+<population_model>
     <age>
         <!--
           The age distribution is a piecewise linear curve connecting
@@ -17,23 +17,27 @@
             <!-- Maximum age for children in families of size >= 3. -->
             <child_maximum>23</child_maximum>
 
-            <!-- Minimum age for parents, in families of size >= 3. -->
-            <parent_minimum>20</parent_minimum>
-
-            <!-- Maximum age for parents, in families of size >= 3. -->
-            <parent_maximum>50</parent_maximum>
+            <!-- Age range for parents, in families of size >= 3. -->
+            <parent>
+                <minimum>20</minimum>
+                <maximum>50</maximum>
+            </parent>
         </age>
         <age_gap>
             <!-- Minimum age gap between children and parents. -->
             <child_parent_minimum>18</child_parent_minimum>
 
             <!-- Inter-parent age gap range. -->
-            <parent_minimum>0</parent_minimum>
-            <parent_maximum>5</parent_maximum>
+            <parent>
+                <minimum>0</minimum>
+                <maximum>5</maximum>
+            </parent>
 
             <!-- Inter-child age gap range. -->
-            <child_minimum>1</child_minimum>
-            <child_maximum>10</child_maximum>
+            <child>
+                <minimum>1</minimum>
+                <maximum>10</maximum>
+            </child>
         </age_gap>
         <size_distribution>
             <p>12</p> <!-- 1 member  -->
@@ -66,8 +70,7 @@
         <p_higher_education>0.25</p_higher_education>
 
         <!-- The size range for schools (in # of students). The distribution is linear. -->
-        <size>
-            <!-- "approximately 500" -->
+        <size> <!-- "approximately 500" -->
             <minimum>450</minimum>
             <maximum>550</maximum>
         </size>
@@ -90,10 +93,13 @@
     </work>
     <community>
         <!-- The size range for communities (in # of members). The distribution is linear. -->
-        <size>
-            <!-- "approximately 2000" -->
+        <size> <!-- "approximately 2000" -->
             <minimum>1800</minimum>
             <maximum>2200</maximum>
         </size>
     </community>
-</popgen>
+    <size>
+        <minimum>18000</minimum>
+        <maximum>22000</maximum>
+    </size>
+</population_model>

--- a/src/test/cpp/gtester/CMakeLists.txt
+++ b/src/test/cpp/gtester/CMakeLists.txt
@@ -1,7 +1,7 @@
 #############################################################################
 #  This is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by 
-#  the Free Software Foundation, either version 3 of the License, or any 
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or any
 #  later version.
 #  The software is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -22,24 +22,25 @@ set( EXEC       gtester     )
 set( SRC
 		main.cpp
 		BatchRuns.cpp
+		ParsePopulationModel.cpp
 )
 
 add_executable(${EXEC}   ${SRC} $<TARGET_OBJECTS:libstride> $<TARGET_OBJECTS:trng>)
-target_link_libraries( ${EXEC}    ${LIBS} gtest pthread) 
+target_link_libraries( ${EXEC}    ${LIBS} gtest pthread)
 install(TARGETS ${EXEC}  DESTINATION   ${BIN_INSTALL_LOCATION})
 
 #============================================================================
 # Define tests.
 #============================================================================
-add_test( NAME  ${EXEC}_default 
+add_test( NAME  ${EXEC}_default
 		WORKING_DIRECTORY  ${TESTS_DIR}
-		COMMAND   ${CMAKE_INSTALL_PREFIX}/${BIN_INSTALL_LOCATION}/${EXEC} 
+		COMMAND   ${CMAKE_INSTALL_PREFIX}/${BIN_INSTALL_LOCATION}/${EXEC}
 			--gtest_filter=*default*  --gtest_output=xml:gtester_default.xml
 )
 
-add_test( NAME  ${EXEC}_all 		
+add_test( NAME  ${EXEC}_all
         WORKING_DIRECTORY  ${TESTS_DIR}
-		COMMAND   ${CMAKE_INSTALL_PREFIX}/${BIN_INSTALL_LOCATION}/${EXEC} 
+		COMMAND   ${CMAKE_INSTALL_PREFIX}/${BIN_INSTALL_LOCATION}/${EXEC}
 		         --gtest_output=xml:gtester_all.xml
 )
 

--- a/src/test/cpp/gtester/ParsePopulationModel.cpp
+++ b/src/test/cpp/gtester/ParsePopulationModel.cpp
@@ -1,0 +1,24 @@
+#include "pop/PopulationModel.h"
+#include <gtest/gtest.h>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/xml_parser.hpp>
+#include <boost/filesystem.hpp>
+#include <iostream>
+
+namespace Tests {
+
+TEST(ParsePopulationModel, ParseDefaultPopulationModel) {
+	std::ifstream pop_file{ "data/popgen_default.xml" };
+	boost::property_tree::ptree pt;
+	boost::property_tree::read_xml(pop_file, pt);
+	stride::PopulationModel model{ pt };
+	pop_file.close();
+
+	EXPECT_EQ(model.elbow_age, 65);
+	EXPECT_DOUBLE_EQ(model.p_higher_education, 0.25);
+	EXPECT_EQ(model.family_size_distribution[0], 12);
+	EXPECT_EQ(model.family_size_distribution[5], 9);
+	EXPECT_EQ(model.family_size_distribution.size(), std::size_t{ 6 });
+}
+
+} // Tests

--- a/src/test/cpp/gtester/ParsePopulationModel.cpp
+++ b/src/test/cpp/gtester/ParsePopulationModel.cpp
@@ -1,15 +1,16 @@
-#include "pop/PopulationModel.h"
-#include <gtest/gtest.h>
+#include <iostream>
+#include <boost/filesystem.hpp>
 #include <boost/property_tree/exceptions.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
-#include <boost/filesystem.hpp>
-#include <iostream>
+#include <gtest/gtest.h>
+#include "pop/PopulationModel.h"
 
 namespace Tests {
 
-TEST(ParsePopulationModel, ParseDefaultPopulationModel) {
-	std::ifstream pop_file{ "data/population_model_default.xml" };
+TEST(ParsePopulationModel, ParseDefaultPopulationModel)
+{
+	std::ifstream pop_file{"data/population_model_default.xml"};
 	boost::property_tree::ptree pt;
 	boost::property_tree::read_xml(pop_file, pt);
 	stride::population_model::Model model;
@@ -19,16 +20,16 @@ TEST(ParsePopulationModel, ParseDefaultPopulationModel) {
 	EXPECT_DOUBLE_EQ(model.school.p_higher_education, 0.25);
 	EXPECT_EQ(model.family.size_distribution[0], 12);
 	EXPECT_EQ(model.family.size_distribution[5], 9);
-	EXPECT_EQ(model.family.size_distribution.size(), std::size_t{ 6 });
+	EXPECT_EQ(model.family.size_distribution.size(), std::size_t{6});
 }
 
-TEST(ParsePopulationModel, ExceptionOnInvalidFile) {
-	std::istringstream pop_file{ "<a>123</a>" };
+TEST(ParsePopulationModel, ExceptionOnInvalidFile)
+{
+	std::istringstream pop_file{"<a>123</a>"};
 	boost::property_tree::ptree pt;
 	boost::property_tree::read_xml(pop_file, pt);
 	stride::population_model::Model model;
 	EXPECT_THROW(model.parse(pt), boost::property_tree::ptree_error);
 }
-
 
 } // Tests

--- a/src/test/cpp/gtester/ParsePopulationModel.cpp
+++ b/src/test/cpp/gtester/ParsePopulationModel.cpp
@@ -1,5 +1,6 @@
 #include "pop/PopulationModel.h"
 #include <gtest/gtest.h>
+#include <boost/property_tree/exceptions.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 #include <boost/filesystem.hpp>
@@ -8,17 +9,26 @@
 namespace Tests {
 
 TEST(ParsePopulationModel, ParseDefaultPopulationModel) {
-	std::ifstream pop_file{ "data/popgen_default.xml" };
+	std::ifstream pop_file{ "data/population_model_default.xml" };
 	boost::property_tree::ptree pt;
 	boost::property_tree::read_xml(pop_file, pt);
-	stride::PopulationModel model{ pt };
-	pop_file.close();
+	stride::population_model::Model model;
+	model.parse(pt);
 
-	EXPECT_EQ(model.elbow_age, 65);
-	EXPECT_DOUBLE_EQ(model.p_higher_education, 0.25);
-	EXPECT_EQ(model.family_size_distribution[0], 12);
-	EXPECT_EQ(model.family_size_distribution[5], 9);
-	EXPECT_EQ(model.family_size_distribution.size(), std::size_t{ 6 });
+	EXPECT_EQ(model.age.elbow, 65);
+	EXPECT_DOUBLE_EQ(model.school.p_higher_education, 0.25);
+	EXPECT_EQ(model.family.size_distribution[0], 12);
+	EXPECT_EQ(model.family.size_distribution[5], 9);
+	EXPECT_EQ(model.family.size_distribution.size(), std::size_t{ 6 });
 }
+
+TEST(ParsePopulationModel, ExceptionOnInvalidFile) {
+	std::istringstream pop_file{ "<a>123</a>" };
+	boost::property_tree::ptree pt;
+	boost::property_tree::read_xml(pop_file, pt);
+	stride::population_model::Model model;
+	EXPECT_THROW(model.parse(pt), boost::property_tree::ptree_error);
+}
+
 
 } // Tests


### PR DESCRIPTION
Here’s what I did so far:

* Translate the population requirements from the assignment PDF into an XML file, where every parameter is configurable. This is `src/main/resources/data/popgen_default.xml`.
* Write an internal struct `PopulationModel` (in `src/main/cpp/pop/PopulationModel.h`) that stores this same data, with a working constructor that accepts a Boost `ptree`.
* Originally, `PopulationBuilder` read a **population data file** in CSV format from the file path specified in `run.population_file` (in the config XML file passed to Stride). Now, if the specified `population_file` is itself XML file, it will be parsed as a **population model file** instead. However, a population is not yet generated from the model (this should be done next!).
* A new Stride configuration, `run_test_popgen.xml`, which reads its population from `popgen_default.xml`, is supplied.