### PR TITLE
Add a dependency on MPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,4 @@ script:
     # `make all; make test`, as per the build instructions.
     - make all
     - make test
+    - cat build/test/Testing/Temporary/LastTest.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
     - cmake --version
     # Build and install boost.
     - wget https://raw.githubusercontent.com/WrinklyNinja/ci-scripts/1.0.0/install_boost.py
-    - python install_boost.py --directory ~ --boost-version 1.61.0 atomic chrono date_time filesystem iostreams locale log regex system thread
+    - python install_boost.py --directory ~ --boost-version 1.61.0 atomic chrono date_time filesystem iostreams locale log regex system thread serialization mpi
     # Set the BOOST_ROOT environment variable.
     - export BOOST_ROOT=$HOME/boost_1_61_0
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ addons:
             - gcc-5
             - g++-5
             - cmake
+            - libopenmpi-dev
             # Don't grab the APT boost package, because that package is stale.
             # We'll need to build boost ourselves.
             # - libboost-all-dev
@@ -34,7 +35,6 @@ before_install:
     # Print the CMake version.
     - cmake --version
     # Build and install boost.
-    - echo "using mpi ;" > ~/site-config.jam
     - wget https://raw.githubusercontent.com/WrinklyNinja/ci-scripts/1.0.0/install_boost.py
     - python install_boost.py --directory ~ --boost-version 1.61.0 atomic chrono date_time filesystem iostreams locale log regex system thread serialization mpi
     # Set the BOOST_ROOT environment variable.

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ addons:
             - gcc-5
             - g++-5
             - cmake
+            - mpich
             - libmpich-dev
             # Don't grab the APT boost package, because that package is stale.
             # We'll need to build boost ourselves.

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
     # Print the CMake version.
     - cmake --version
     # Build and install boost.
-    - echo "using mpi ;" > ~/user-config.jam
+    - echo "using mpi ;" > ~/site-config.jam
     - wget https://raw.githubusercontent.com/WrinklyNinja/ci-scripts/1.0.0/install_boost.py
     - python install_boost.py --directory ~ --boost-version 1.61.0 atomic chrono date_time filesystem iostreams locale log regex system thread serialization mpi
     # Set the BOOST_ROOT environment variable.

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ before_install:
     # Print the CMake version.
     - cmake --version
     # Build and install boost.
+    - echo "using mpi ;" > ~/user-config.jam
     - wget https://raw.githubusercontent.com/WrinklyNinja/ci-scripts/1.0.0/install_boost.py
     - python install_boost.py --directory ~ --boost-version 1.61.0 atomic chrono date_time filesystem iostreams locale log regex system thread serialization mpi
     # Set the BOOST_ROOT environment variable.

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ before_install:
     # Print the CMake version.
     - cmake --version
     # Build and install boost.
+    - echo "using mpi ;" > ~/site-config.jam
     - wget https://raw.githubusercontent.com/WrinklyNinja/ci-scripts/1.0.0/install_boost.py
     - python install_boost.py --directory ~ --boost-version 1.61.0 atomic chrono date_time filesystem iostreams locale log regex system thread serialization mpi
     # Set the BOOST_ROOT environment variable.

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ before_install:
     - python install_boost.py --directory ~ --boost-version 1.61.0 atomic chrono date_time filesystem iostreams locale log regex system thread serialization mpi
     # Set the BOOST_ROOT environment variable.
     - export BOOST_ROOT=$HOME/boost_1_61_0
+    - export LD_LIBRARY_PATH=$HOME/boost_1_61_0/stage/lib:$LD_LIBRARY_PATH
 
 script:
     # `make all; make test`, as per the build instructions.

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,5 +45,5 @@ before_install:
 script:
     # `make all; make test`, as per the build instructions.
     - make all
-    - make test
+    - make test_all
     - cat build/test/Testing/Temporary/LastTest.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ addons:
             - gcc-5
             - g++-5
             - cmake
-            - libopenmpi-dev
+            - libmpich-dev
             # Don't grab the APT boost package, because that package is stale.
             # We'll need to build boost ourselves.
             # - libboost-all-dev

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,9 @@ distclean clean:
 	$(CMAKE) -E remove_directory $(BUILD_DIR)
 
 test installcheck: install_test
-	$(MAKE) -C $(BUILD_DIR)/test --no-print-directory run_ctest 
+	$(MAKE) -C $(BUILD_DIR)/test --no-print-directory run_ctest
+
+test_all: install_test
+	$(MAKE) -C $(BUILD_DIR)/test --no-print-directory run_ctest_all
 	
 #############################################################################

--- a/src/CMakeCPPConfig.txt
+++ b/src/CMakeCPPConfig.txt
@@ -74,6 +74,13 @@ include_directories( SYSTEM ${CMAKE_HOME_DIRECTORY}/main/resources/lib/trng-4.15
 #set( LIBS ${LIBS} trng )
 
 #----------------------------------------------------------------------------
+# MPI compile flags
+#----------------------------------------------------------------------------
+find_package( MPI )
+include_directories( SYSTEM ${MPI_INCLUDE_PATH} )
+set( LIBS ${LIBS} ${MPI_CXX_LIBRARIES} )
+
+#----------------------------------------------------------------------------
 # Boost
 #----------------------------------------------------------------------------
 set(BOOST_ROOT ${STRIDE_BOOST_ROOT})

--- a/src/CMakeCPPConfig.txt
+++ b/src/CMakeCPPConfig.txt
@@ -77,7 +77,7 @@ include_directories( SYSTEM ${CMAKE_HOME_DIRECTORY}/main/resources/lib/trng-4.15
 # Boost
 #----------------------------------------------------------------------------
 set(BOOST_ROOT ${STRIDE_BOOST_ROOT})
-find_package( Boost COMPONENTS filesystem thread date_time system REQUIRED )
+find_package( Boost COMPONENTS filesystem thread date_time system mpi serialization REQUIRED )
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS} )
 set( LIBS   ${LIBS} ${Boost_LIBRARIES} )
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -35,6 +35,10 @@ add_custom_target( run_ctest
 	COMMAND ctest --tests-regex default ${CTEST_VERBOSE_OPTION} 
 				-O ${TESTS_DIR}/ctests_default.txt
 )
+add_custom_target( run_ctest_all
+	COMMAND ctest --tests-regex all ${CTEST_VERBOSE_OPTION} 
+				-O ${TESTS_DIR}/ctests_all.txt
+)
 
 #============================================================================
 # Config related to using Google test (src in resources/lib/gtest) for cpp

--- a/src/test/cpp/gtester/CMakeLists.txt
+++ b/src/test/cpp/gtester/CMakeLists.txt
@@ -23,6 +23,7 @@ set( SRC
 		main.cpp
 		BatchRuns.cpp
 		ParsePopulationModel.cpp
+		MpiTests.cpp
 )
 
 add_executable(${EXEC}   ${SRC} $<TARGET_OBJECTS:libstride> $<TARGET_OBJECTS:trng>)

--- a/src/test/cpp/gtester/MpiTests.cpp
+++ b/src/test/cpp/gtester/MpiTests.cpp
@@ -1,0 +1,23 @@
+#include <iostream>
+#include <boost/filesystem.hpp>
+#include <boost/property_tree/exceptions.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/xml_parser.hpp>
+#include <boost/mpi/environment.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <gtest/gtest.h>
+#include "pop/PopulationModel.h"
+
+namespace mpi = boost::mpi;
+
+namespace Tests {
+
+TEST(Mpi, GetEnvironment)
+{
+	mpi::environment env;
+	mpi::communicator world;
+	std::cout << "I am process " << world.rank() << " of " << world.size()
+	<< "." << std::endl;
+}
+
+} // Tests

--- a/src/test/cpp/gtester/ParsePopulationModel.cpp
+++ b/src/test/cpp/gtester/ParsePopulationModel.cpp
@@ -10,7 +10,7 @@ namespace Tests {
 
 TEST(ParsePopulationModel, ParseDefaultPopulationModel)
 {
-	std::ifstream pop_file{"data/population_model_default.xml"};
+	std::ifstream pop_file{"../data/population_model_default.xml"};
 	boost::property_tree::ptree pt;
 	boost::property_tree::read_xml(pop_file, pt);
 	stride::population_model::Model model;


### PR DESCRIPTION
If merged in, this PR will make our project dependent on MPI and the Boost MPI library. I included a test to make sure that MPI code builds and runs and our Travis CI configuration has been updated to install the `libopenmpi-dev` package, build the Boost MPI library, and print the `gtest` log.

Possibly unrelated to MPI: I have also defined a Makefile rule (`make test_all`) that actually runs all tests (apparently `make test` didn't do that) but I haven't configured Travis to use it; apparently, the synthetic population generation test fails, but this was obscured by the fact that `make test` only runs three tests.

**Update:** I fixed the failing test and have now configured Travis to run all tests.