### PR TITLE
Implement working shared-memory, multi-region simulation

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -42,6 +42,7 @@ set(LIB_SRC
     output/SummaryFile.cpp
 #---	
     pop/Person.cpp
+    pop/Population.cpp
     pop/PopulationBuilder.cpp
     pop/PopulationGenerator.cpp
     pop/PopulationModel.cpp

--- a/src/main/cpp/alias/Alias.cpp
+++ b/src/main/cpp/alias/Alias.cpp
@@ -8,12 +8,25 @@
 namespace stride {
 namespace alias {
 
+void NormalizeProbabilities(std::vector<double>& probabilities)
+{
+	double sum = 0.0;
+	for (auto item : probabilities) {
+		sum += item;
+	}
+
+	for (auto& item : probabilities) {
+		item /= sum;
+	}
+}
+
 Alias Alias::CreateDistribution(std::vector<double> probabilities, util::Random& rng)
 {
 	assert(probabilities.size() > 0);
 	if (probabilities.size() <= 0) {
 		throw EmptyProbabilityException();
 	}
+	NormalizeProbabilities(probabilities);
 	std::size_t n = probabilities.size();
 	std::vector<double> prob(n);
 	std::vector<std::size_t> alias(n);
@@ -56,22 +69,10 @@ Alias Alias::CreateDistribution(std::vector<double> probabilities, util::Random&
 	return std::move(a);
 }
 
-void Alias::NormalizeProbabilities(std::vector<double>& probabilities)
-{
-	double sum = 0.0;
-	for (auto item : probabilities) {
-		sum += item;
-	}
-
-	for (auto& item : probabilities) {
-		item /= sum;
-	}
-}
-
 std::size_t Alias::Next()
 {
-	std::size_t roll = m_random(m_alias.size());
-	double flip = m_random.NextDouble();
+	std::size_t roll = (*m_random)(m_alias.size());
+	double flip = m_random->NextDouble();
 	if (flip <= m_prob[roll]) {
 		return roll;
 	} else {

--- a/src/main/cpp/alias/Alias.cpp
+++ b/src/main/cpp/alias/Alias.cpp
@@ -1,16 +1,9 @@
-/*
- * Alias.cpp
- *
- *  Created on: Mar 11, 2017
- *      Author: cedric
- */
-
 #include "Alias.h"
-#include "AliasUtil.h"
 
 #include <exception>
 #include <assert.h>
 #include <math.h>
+#include "AliasUtil.h"
 
 namespace stride {
 namespace alias {

--- a/src/main/cpp/alias/Alias.cpp
+++ b/src/main/cpp/alias/Alias.cpp
@@ -59,8 +59,20 @@ Alias Alias::CreateDistribution(std::vector<double> probabilities, util::Random&
 	for (auto l : small) {
 		prob[l] = 1;
 	}
-	Alias a(alias, prob, rng);
+	Alias a(std::move(alias), std::move(prob), rng);
 	return std::move(a);
+}
+
+void Alias::NormalizeProbabilities(std::vector<double>& probabilities)
+{
+	double sum = 0.0;
+	for (auto item : probabilities) {
+		sum += item;
+	}
+
+	for (auto& item : probabilities) {
+		item /= sum;
+	}
 }
 
 unsigned int Alias::Next()

--- a/src/main/cpp/alias/Alias.cpp
+++ b/src/main/cpp/alias/Alias.cpp
@@ -21,14 +21,14 @@ Alias Alias::CreateDistribution(std::vector<double> probabilities, util::Random&
 	if (probabilities.size() <= 0) {
 		throw EmptyProbabilityException();
 	}
-	unsigned int n = probabilities.size();
+	std::size_t n = probabilities.size();
 	std::vector<double> prob(n);
-	std::vector<unsigned int> alias(n);
-	std::vector<unsigned int> small, large;
+	std::vector<std::size_t> alias(n);
+	std::vector<std::size_t> small, large;
 	for (auto& i : probabilities) {
 		i *= n;
 	}
-	for (unsigned int i = 0; i < probabilities.size(); i++) {
+	for (std::size_t i = 0; i < probabilities.size(); i++) {
 		if (probabilities[i] < 1.0) {
 			small.push_back(i);
 		} else {
@@ -37,9 +37,9 @@ Alias Alias::CreateDistribution(std::vector<double> probabilities, util::Random&
 	}
 
 	while (!(small.empty() || large.empty())) {
-		unsigned int l = large.front();
+		std::size_t l = large.front();
 		large.erase(large.begin());
-		unsigned int g = small.front();
+		std::size_t g = small.front();
 		small.erase(small.begin());
 		prob[l] = probabilities[l];
 		alias[l] = g;
@@ -75,9 +75,9 @@ void Alias::NormalizeProbabilities(std::vector<double>& probabilities)
 	}
 }
 
-unsigned int Alias::Next()
+std::size_t Alias::Next()
 {
-	unsigned int roll = m_random(m_alias.size());
+	std::size_t roll = m_random(m_alias.size());
 	double flip = m_random.NextDouble();
 	if (flip <= m_prob[roll]) {
 		return roll;

--- a/src/main/cpp/alias/Alias.h
+++ b/src/main/cpp/alias/Alias.h
@@ -66,7 +66,7 @@ public:
 	/// Creates a biased random value generator from the given value-to-probability map and
 	/// random number generator.
 	template <typename TProbabilityMap>
-	static BiasedRandomValueGenerator<T> CreateDistribution(TProbabilityMap probabilities, util::Random& rng)
+	static BiasedRandomValueGenerator<T> CreateDistribution(const TProbabilityMap& probabilities, util::Random& rng)
 	{
 		std::vector<T> value_map;
 		std::vector<double> prob_vector;

--- a/src/main/cpp/alias/Alias.h
+++ b/src/main/cpp/alias/Alias.h
@@ -41,11 +41,11 @@ public:
 	static void NormalizeProbabilities(std::vector<double>& probabilities);
 
 	/// Generates a new number.
-	unsigned int Next();
+	std::size_t Next();
 
 private:
 	/// Constructor
-	Alias(std::vector<unsigned int>&& alias, std::vector<double>&& prob, util::Random& rng)
+	Alias(std::vector<std::size_t>&& alias, std::vector<double>&& prob, util::Random& rng)
 	    : m_random{rng}, m_alias{alias}, m_prob{prob}
 	{
 	}
@@ -54,7 +54,7 @@ private:
 	util::Random& m_random;
 
 	/// The vector of aliases
-	std::vector<unsigned int> m_alias;
+	std::vector<std::size_t> m_alias;
 
 	/// The vector of probabilities
 	std::vector<double> m_prob;

--- a/src/main/cpp/alias/Alias.h
+++ b/src/main/cpp/alias/Alias.h
@@ -1,11 +1,16 @@
 #ifndef ALIAS_H_INCLUDED
 #define ALIAS_H_INCLUDED
 
+#include <unordered_map>
 #include <vector>
 #include "util/Random.h"
 
 namespace stride {
 namespace alias {
+
+/// Normalizes the given list of probabilities: every element is
+/// divided by the sum of the elements in the list.
+void NormalizeProbabilities(std::vector<double>& probabilities);
 
 /**
  * Class used to generate random numbers according to Vose's Alias Method.
@@ -15,24 +20,15 @@ namespace alias {
 class Alias
 {
 public:
-	/// No standard constructor needed
 	Alias() = delete;
-
-	/// No copy constructor needed
 	Alias(const Alias&) = delete;
-
-	/// No assignment operator needed
 	Alias& operator=(const Alias&) = delete;
 
-	/// Move constructor
 	Alias(Alias&& other) = default;
+	Alias& operator=(Alias&& other) = default;
 
 	/// Creates an Alias object.
 	static Alias CreateDistribution(std::vector<double> probabilities, util::Random& rng);
-
-	/// Normalizes the given list of probabilities: every element is
-	/// divided by the sum of the elements in the list.
-	static void NormalizeProbabilities(std::vector<double>& probabilities);
 
 	/// Generates a new number.
 	std::size_t Next();
@@ -40,18 +36,58 @@ public:
 private:
 	/// Constructor
 	Alias(std::vector<std::size_t>&& alias, std::vector<double>&& prob, util::Random& rng)
-	    : m_random{rng}, m_alias{alias}, m_prob{prob}
+	    : m_random(&rng), m_alias(std::move(alias)), m_prob(std::move(prob))
 	{
 	}
 
 	/// The random number generator
-	util::Random& m_random;
+	util::Random* m_random;
 
 	/// The vector of aliases
 	std::vector<std::size_t> m_alias;
 
 	/// The vector of probabilities
 	std::vector<double> m_prob;
+};
+
+/// A type that generates random values. The odds of each random value occurring
+/// are controlled by a probability.
+template <typename T>
+class BiasedRandomValueGenerator
+{
+public:
+	BiasedRandomValueGenerator() = delete;
+	BiasedRandomValueGenerator(const BiasedRandomValueGenerator&) = delete;
+	BiasedRandomValueGenerator& operator=(const BiasedRandomValueGenerator&) = delete;
+
+	BiasedRandomValueGenerator(BiasedRandomValueGenerator&& other) = default;
+	BiasedRandomValueGenerator& operator=(BiasedRandomValueGenerator&& other) = default;
+
+	/// Creates a biased random value generator from the given value-to-probability map and
+	/// random number generator.
+	template <typename TProbabilityMap>
+	static BiasedRandomValueGenerator<T> CreateDistribution(TProbabilityMap probabilities, util::Random& rng)
+	{
+		std::vector<T> value_map;
+		std::vector<double> prob_vector;
+		for (const auto& pair : probabilities) {
+			value_map.push_back(pair.first);
+			prob_vector.push_back(pair.second);
+		}
+		auto inner = Alias::CreateDistribution(prob_vector, rng);
+		return {std::move(inner), std::move(value_map)};
+	}
+
+	/// Generates a new value.
+	T Next() { return value_map[inner_alias.Next()]; }
+
+private:
+	BiasedRandomValueGenerator(Alias&& inner_alias, std::vector<T>&& value_map)
+	    : inner_alias(std::move(inner_alias)), value_map(std::move(value_map))
+	{
+	}
+	Alias inner_alias;
+	std::vector<T> value_map;
 };
 }
 }

--- a/src/main/cpp/alias/Alias.h
+++ b/src/main/cpp/alias/Alias.h
@@ -9,8 +9,10 @@
 
 #include <vector>
 #include <util/Random.h>
+
 namespace stride {
 namespace alias {
+
 /**
  * Class used to generate random numbers according to Vose's Alias Method.
  * Used the algorithm on http://keithschwarz.com/darts-dice-coins/
@@ -18,31 +20,44 @@ namespace alias {
  */
 class Alias
 {
-    public:
+public:
 	/// No standard constructor needed
 	Alias() = delete;
+
 	/// No copy constructor needed
 	Alias(const Alias&) = delete;
-	/// No assignement operator needed
+
+	/// No assignment operator needed
 	Alias& operator=(const Alias&) = delete;
+
 	/// Move constructor
-	Alias(const Alias&& other) : m_random{other.m_random}, m_alias{other.m_alias}, m_prob{other.m_prob}
-	{
-	}
+	Alias(Alias&& other) = default;
+
 	/// Creates an Alias object.
 	static Alias CreateDistribution(std::vector<double> probabilities, util::Random& rng);
-	/// Generates a new number
+
+	/// Normalizes the given list of probabilities: every element is
+	/// divided by the sum of the elements in the list.
+	static void NormalizeProbabilities(std::vector<double>& probabilities);
+
+	/// Generates a new number.
 	unsigned int Next();
 
-    private:
+private:
 	/// Constructor
-	Alias(std::vector<unsigned int> alias, std::vector<double> prob, util::Random& rng)
+	Alias(std::vector<unsigned int>&& alias, std::vector<double>&& prob, util::Random& rng)
 	    : m_random{rng}, m_alias{alias}, m_prob{prob}
 	{
 	}
-	util::Random& m_random;		   ///< The random number generator
-	std::vector<unsigned int> m_alias; ///< The vector of aliases
-	std::vector<double> m_prob;	///< The vector of probabilities
+
+	/// The random number generator
+	util::Random& m_random;
+
+	/// The vector of aliases
+	std::vector<unsigned int> m_alias;
+
+	/// The vector of probabilities
+	std::vector<double> m_prob;
 };
 }
 }

--- a/src/main/cpp/alias/Alias.h
+++ b/src/main/cpp/alias/Alias.h
@@ -1,14 +1,8 @@
-/*
- * Alias.h
- *
- *  Created on: Mar 11, 2017
- *      Author: cedric
- */
 #ifndef ALIAS_H_INCLUDED
 #define ALIAS_H_INCLUDED
 
 #include <vector>
-#include <util/Random.h>
+#include "util/Random.h"
 
 namespace stride {
 namespace alias {

--- a/src/main/cpp/alias/AliasUtil.h
+++ b/src/main/cpp/alias/AliasUtil.h
@@ -1,25 +1,16 @@
-/*
- * AliasUtil.h
- *
- *  Created on: Mar 12, 2017
- *      Author: cedric
- */
-#include <exception>
+#ifndef ALIAS_UTIL_H_INCLUDED
+#define ALIAS_UTIL_H_INCLUDED
 
-#ifndef ALIASUTIL_H_INCLUDED
-#define ALIASUTIL_H_INCLUDED
+#include <exception>
 
 /**
  * An exception to throw when an empty vector is given to the Alias constructor
  */
 class EmptyProbabilityException : public std::exception
 {
-    public:
+public:
 	/// Returns the problem
-	virtual const char* what() const throw()
-	{
-		return "Tried to do Alias without chances.";
-	}
+	virtual const char* what() const throw() { return "Tried to do Alias without chances."; }
 };
 
-#endif /* ALIASUTIL_H_ */
+#endif

--- a/src/main/cpp/core/Cluster.cpp
+++ b/src/main/cpp/core/Cluster.cpp
@@ -65,6 +65,7 @@ void Cluster::RemovePerson(Person* p)
                         }
                         return;
                 }
+                index++;
         }
 }
 

--- a/src/main/cpp/core/Cluster.cpp
+++ b/src/main/cpp/core/Cluster.cpp
@@ -54,6 +54,20 @@ void Cluster::AddPerson(Person* p)
         m_index_immune++;
 }
 
+void Cluster::RemovePerson(Person* p)
+{
+        std::size_t index = 0;
+        while (index < m_members.size()) {
+                if (m_members[index].first == p) {
+                        m_members.erase(m_members.begin() + index);
+                        if (m_index_immune == index) {
+                                m_index_immune++;
+                        }
+                        return;
+                }
+        }
+}
+
 tuple<bool, std::size_t> Cluster::SortMembers()
 {
         bool infectious_cases = false;

--- a/src/main/cpp/core/Cluster.cpp
+++ b/src/main/cpp/core/Cluster.cpp
@@ -10,7 +10,8 @@
  *  You should have received a copy of the GNU General Public License
  *  along with the software. If not, see <http://www.gnu.org/licenses/>.
  *
- *  Copyright 2017, Willem L, Kuylen E, Stijven S & Broeckhove J
+ *  Copyright 2017, Willem L, Kuylen E, Stijven S, Broeckhove J
+ *  Aerts S, De Haes C, Van der Cruysse J & Van Hauwe L
  */
 
 /**
@@ -48,13 +49,13 @@ void Cluster::AddContactProfile(ClusterType cluster_type, const ContactProfile& 
 }
 
 
-void Cluster::AddPerson(Person* p)
+void Cluster::AddPerson(const Person& p)
 {
         m_members.emplace_back(std::make_pair(p, true));
         m_index_immune++;
 }
 
-void Cluster::RemovePerson(Person* p)
+void Cluster::RemovePerson(const Person& p)
 {
         std::size_t index = 0;
         while (index < m_members.size()) {
@@ -79,12 +80,12 @@ tuple<bool, std::size_t> Cluster::SortMembers()
 
         for (size_t i_member = 0; i_member < m_index_immune; i_member++) {
                 // if immune, move to back
-                if (m_members[i_member].first->GetHealth().IsImmune()) {
+                if (m_members[i_member].first.GetHealth().IsImmune()) {
                         bool swapped = false;
                         std::size_t new_place = m_index_immune - 1;
                         m_index_immune--;
                         while(! swapped && new_place > i_member) {
-                                if (m_members[new_place].first->GetHealth().IsImmune()) {
+                                if (m_members[new_place].first.GetHealth().IsImmune()) {
                                         m_index_immune--;
                                         new_place--;
                                 } else {
@@ -94,8 +95,8 @@ tuple<bool, std::size_t> Cluster::SortMembers()
                         }
                 }
                 // else, if not susceptible, move to front
-                else if (!m_members[i_member].first->GetHealth().IsSusceptible()) {
-                        if (!infectious_cases && m_members[i_member].first->GetHealth().IsInfectious()) {
+                else if (!m_members[i_member].first.GetHealth().IsSusceptible()) {
+                        if (!infectious_cases && m_members[i_member].first.GetHealth().IsInfectious()) {
                                 infectious_cases = true;
                         }
                         if (i_member > num_cases) {
@@ -111,7 +112,7 @@ tuple<bool, std::size_t> Cluster::SortMembers()
 void Cluster::UpdateMemberPresence()
 {
         for (auto& member: m_members) {
-                member.second = member.first->IsInCluster(m_cluster_type);
+                member.second = member.first.IsInCluster(m_cluster_type);
         }
 }
 

--- a/src/main/cpp/core/Cluster.cpp
+++ b/src/main/cpp/core/Cluster.cpp
@@ -54,16 +54,16 @@ void Cluster::AddPerson(Person* p)
         m_index_immune++;
 }
 
-tuple<bool, size_t> Cluster::SortMembers()
+tuple<bool, std::size_t> Cluster::SortMembers()
 {
         bool infectious_cases = false;
-        size_t num_cases = 0;
+        std::size_t num_cases = 0;
 
         for (size_t i_member = 0; i_member < m_index_immune; i_member++) {
                 // if immune, move to back
                 if (m_members[i_member].first->GetHealth().IsImmune()) {
                         bool swapped = false;
-                        size_t new_place = m_index_immune - 1;
+                        std::size_t new_place = m_index_immune - 1;
                         m_index_immune--;
                         while(! swapped && new_place > i_member) {
                                 if (m_members[new_place].first->GetHealth().IsImmune()) {

--- a/src/main/cpp/core/Cluster.cpp
+++ b/src/main/cpp/core/Cluster.cpp
@@ -51,8 +51,16 @@ void Cluster::AddContactProfile(ClusterType cluster_type, const ContactProfile& 
 
 void Cluster::AddPerson(const Person& p)
 {
-        m_members.emplace_back(std::make_pair(p, true));
-        m_index_immune++;
+        if (p.GetHealth().IsImmune()) {
+                m_members.emplace_back(
+                        std::make_pair(p, p.IsInCluster(m_cluster_type)));
+        }
+        else {
+                m_members.emplace(
+                        m_members.begin() + m_index_immune,
+                        std::make_pair(p, p.IsInCluster(m_cluster_type)));
+                m_index_immune++;
+        }
 }
 
 void Cluster::RemovePerson(const Person& p)

--- a/src/main/cpp/core/Cluster.cpp
+++ b/src/main/cpp/core/Cluster.cpp
@@ -63,6 +63,9 @@ void Cluster::RemovePerson(Person* p)
                         if (m_index_immune == index) {
                                 m_index_immune++;
                         }
+                        if (m_index_immune > m_members.size()) {
+                                m_index_immune = m_members.size();
+                        }
                         return;
                 }
                 index++;

--- a/src/main/cpp/core/Cluster.h
+++ b/src/main/cpp/core/Cluster.h
@@ -68,7 +68,7 @@ public:
 
 private:
 	/// Sort members w.r.t. health status (order: exposed/infected/recovered, susceptible, immune).
-	std::tuple<bool, size_t> SortMembers();
+	std::tuple<bool, std::size_t> SortMembers();
 
 	/// Infector calculates contacts and transmissions.
         template<LogMode log_level, bool track_index_case>

--- a/src/main/cpp/core/Cluster.h
+++ b/src/main/cpp/core/Cluster.h
@@ -50,6 +50,9 @@ public:
 	/// Add the given Person to the Cluster.
 	void AddPerson(Person* p);
 
+	/// Removes the given person from this cluster.
+	void RemovePerson(Person* p);
+
 	/// Return number of persons in this cluster.
 	std::size_t GetSize() const { return m_members.size(); }
 

--- a/src/main/cpp/core/Cluster.h
+++ b/src/main/cpp/core/Cluster.h
@@ -12,7 +12,8 @@
  *  You should have received a copy of the GNU General Public License
  *  along with the software. If not, see <http://www.gnu.org/licenses/>.
  *
- *  Copyright 2017, Willem L, Kuylen E, Stijven S & Broeckhove J
+ *  Copyright 2017, Willem L, Kuylen E, Stijven S, Broeckhove J
+ *  Aerts S, De Haes C, Van der Cruysse J & Van Hauwe L
  */
 
 /**
@@ -48,10 +49,10 @@ public:
         //Cluster(const Cluster& rhs);
 
 	/// Add the given Person to the Cluster.
-	void AddPerson(Person* p);
+	void AddPerson(const Person& p);
 
 	/// Removes the given person from this cluster.
-	void RemovePerson(Person* p);
+	void RemovePerson(const Person& p);
 
 	/// Return number of persons in this cluster.
 	std::size_t GetSize() const { return m_members.size(); }
@@ -60,9 +61,9 @@ public:
 	ClusterType GetClusterType() const { return m_cluster_type; }
 
 	/// Get basic contact rate in this cluster.
-	double GetContactRate(const Person* p) const
+	double GetContactRate(const Person& p) const
 	{
-		return g_profiles.at(ToSizeType(m_cluster_type))[EffectiveAge(p->GetAge())] / m_members.size();;
+		return g_profiles.at(ToSizeType(m_cluster_type))[EffectiveAge(p.GetAge())] / m_members.size();;
 	}
 
 public:
@@ -84,7 +85,7 @@ private:
 	std::size_t                               m_cluster_id;     ///< The ID of the Cluster (for logging purposes).
 	ClusterType                               m_cluster_type;   ///< The type of the Cluster (for logging purposes).
 	std::size_t                               m_index_immune;   ///< Index of the first immune member in the Cluster.
-	std::vector<std::pair<Person*, bool>>     m_members;        ///< Container with pointers to Cluster members.
+	std::vector<std::pair<Person, bool>>      m_members;        ///< Container with pointers to Cluster members.
 	const ContactProfile&                     m_profile;
 private:
 	static std::array<ContactProfile, NumOfClusterTypes()> g_profiles;

--- a/src/main/cpp/core/Health.h
+++ b/src/main/cpp/core/Health.h
@@ -119,7 +119,7 @@ private:
 	HealthStatus m_status;
 
 	/// Times after infection at which the disease will act.
-	const disease::Fate m_fate;
+	disease::Fate m_fate;
 };
 
 } // end of namespace

--- a/src/main/cpp/core/Infector.cpp
+++ b/src/main/cpp/core/Infector.cpp
@@ -117,7 +117,7 @@ void Infector<log_level, track_index_case>::Execute(
 {
         // check if the cluster has infected members and sort
         bool infectious_cases;
-        size_t num_cases;
+        std::size_t num_cases;
         tie(infectious_cases, num_cases) = cluster.SortMembers();
 
         if (infectious_cases) {

--- a/src/main/cpp/multiregion/LocalSimulationTask.h
+++ b/src/main/cpp/multiregion/LocalSimulationTask.h
@@ -43,7 +43,7 @@ public:
 		result.BeforeSimulatorStep(*sim->GetPopulation());
 		sim->TimeStep();
 		result.AfterSimulatorStep(*sim->GetPopulation());
-		communicator.Push({}, {});
+		communicator.Push(SimulationStepOutput());
 	}
 
 	/// Applies the given aggregation function to this simulation task's population.

--- a/src/main/cpp/multiregion/LocalSimulationTask.h
+++ b/src/main/cpp/multiregion/LocalSimulationTask.h
@@ -39,11 +39,11 @@ public:
 	/// Performs a single step in the simulation.
 	void Step()
 	{
-		auto pull = communicator.Pull();
+		auto pull_data = communicator.Pull();
 		result.BeforeSimulatorStep(*sim->GetPopulation());
-		sim->TimeStep();
+		auto push_data = sim->TimeStep(pull_data);
 		result.AfterSimulatorStep(*sim->GetPopulation());
-		communicator.Push(SimulationStepOutput());
+		communicator.Push(push_data);
 	}
 
 	/// Applies the given aggregation function to this simulation task's population.

--- a/src/main/cpp/multiregion/LocalSimulationTask.h
+++ b/src/main/cpp/multiregion/LocalSimulationTask.h
@@ -1,0 +1,69 @@
+#ifndef LOCAL_SIMULATION_TASK_H_INCLUDED
+#define LOCAL_SIMULATION_TASK_H_INCLUDED
+
+/**
+ * @file
+ * Defines a type of simulation task that runs in the current process.
+ */
+
+#include <memory>
+#include <unordered_set>
+#include "multiregion/SimulationManager.h"
+#include "multiregion/Visitor.h"
+#include "sim/Simulator.h"
+#include "sim/SimulatorBuilder.h"
+
+namespace stride {
+namespace multiregion {
+
+/**
+ * A simulation task that runs in the current process.
+ */
+template <typename TResult, typename TCommunicator>
+class LocalSimulationTask final : public SimulationTask<TResult>
+{
+public:
+	template <typename... TInitialResultArgs>
+	LocalSimulationTask(
+	    const std::shared_ptr<Simulator>& sim, const TCommunicator& communicator, TInitialResultArgs... args)
+	    : sim(sim), communicator(communicator), result(args...)
+	{
+	}
+
+	/// Fetches this simulation task's result.
+	TResult GetResult() final override { return result; }
+
+	/// Tells if this simulation is done.
+	bool IsDone() const { return sim->IsDone(); }
+
+	/// Performs a single step in the simulation.
+	void Step()
+	{
+		auto pull = communicator.Pull();
+		result.BeforeSimulatorStep(*sim->GetPopulation());
+		sim->TimeStep();
+		result.AfterSimulatorStep(*sim->GetPopulation());
+		communicator.Push({}, {});
+	}
+
+	/// Applies the given aggregation function to this simulation task's population.
+	boost::any AggregateAny(std::function<boost::any(const PopulationRef&)> apply) final override
+	{
+		return apply(sim->GetPopulation());
+	}
+
+	/// Gets the set of all regions that are connected to this region by an air route.
+	const std::unordered_set<RegionId>& GetConnectedRegions() const
+	{
+		return sim->GetConfiguration().travel_model->GetConnectedRegions();
+	}
+
+private:
+	std::shared_ptr<Simulator> sim;
+	TCommunicator communicator;
+	TResult result;
+};
+}
+}
+
+#endif

--- a/src/main/cpp/multiregion/ParallelSimulationManager.h
+++ b/src/main/cpp/multiregion/ParallelSimulationManager.h
@@ -35,16 +35,16 @@ private:
 		{
 		}
 
-		PullResult Pull()
+		SimulationStepInput Pull()
 		{
 			std::lock_guard<std::mutex> lock(manager->comm_mutex);
 			return manager->comm_data.Pull(id);
 		}
 
-		void Push(const std::vector<OutgoingVisitor>& visitors, const std::vector<OutgoingVisitor>& expatriates)
+		void Push(const SimulationStepOutput& data)
 		{
 			std::lock_guard<std::mutex> lock(manager->comm_mutex);
-			manager->comm_data.Push(id, manager->tasks[id]->GetConnectedRegions(), visitors, expatriates);
+			manager->comm_data.Push(id, manager->tasks[id]->GetConnectedRegions(), data);
 		}
 
 	private:

--- a/src/main/cpp/multiregion/ParallelSimulationManager.h
+++ b/src/main/cpp/multiregion/ParallelSimulationManager.h
@@ -7,6 +7,7 @@
  */
 
 #include <memory>
+#include <mutex>
 #include <thread>
 #include <omp.h>
 #include <spdlog/spdlog.h>
@@ -19,57 +20,56 @@ namespace stride {
 namespace multiregion {
 
 /**
- * A parallel simulation task.
- */
-template <typename TResult>
-class ParallelSimulationTask final : public SimulationTask<TResult>
-{
-public:
-	template <typename... TInitialResultArgs>
-	ParallelSimulationTask(const std::shared_ptr<Simulator>& sim, TInitialResultArgs... args)
-	    : sequential_task(sim, args...)
-	{
-	}
-
-	/// Fetches this simulation task's result.
-	TResult GetResult() final override { return sequential_task.GetResult(); }
-
-	/// Starts this simulation.
-	void Start() final override
-	{
-		if (task_thread != nullptr)
-			return;
-
-		task_thread =
-		    std::make_shared<std::thread>(&SequentialSimulationTask<TResult>::Start, &sequential_task);
-	}
-
-	/// Waits for this simulation to complete.
-	void Wait() final override
-	{
-		Start();
-		task_thread->join();
-	}
-
-	/// Applies the given aggregation function to this simulation task's population.
-	boost::any AggregateAny(std::function<boost::any(const PopulationRef&)> apply) final override
-	{
-		return sequential_task.AggregateAny(apply);
-	}
-
-private:
-	std::shared_ptr<std::thread> task_thread;
-	SequentialSimulationTask<TResult> sequential_task;
-};
-
-/**
  * A parallel simulation manager implementation.
  */
 template <typename TResult, typename... TInitialResultArgs>
 class ParallelSimulationManager final : public SimulationManager<TResult, TInitialResultArgs...>
 {
+private:
+	class ParallelTaskCommunicator final
+	{
+	public:
+		ParallelTaskCommunicator(
+		    RegionId id, ParallelSimulationManager<TResult, TInitialResultArgs...>* manager)
+		    : id(id), manager(manager)
+		{
+		}
+
+		PullResult Pull()
+		{
+			std::lock_guard<std::mutex> lock(manager->comm_mutex);
+			return manager->comm_data.Pull(id);
+		}
+
+		void Push(const std::vector<OutgoingVisitor>& visitors, const std::vector<OutgoingVisitor>& expatriates)
+		{
+			std::lock_guard<std::mutex> lock(manager->comm_mutex);
+			manager->comm_data.Push(id, manager->tasks[id]->GetConnectedRegions(), visitors, expatriates);
+		}
+
+	private:
+		RegionId id;
+		ParallelSimulationManager<TResult, TInitialResultArgs...>* manager;
+	};
+
+	bool TryPopReadyAtomic(RegionId& id)
+	{
+		std::lock_guard<std::mutex> lock(comm_mutex);
+		return comm_data.TryPopReady(id);
+	}
+
+	TaskCommunicationData comm_data;
+	std::unordered_map<RegionId, std::shared_ptr<SequentialSimulationTask<TResult, ParallelTaskCommunicator>>>
+	    tasks;
+	std::mutex comm_mutex;
+	std::size_t number_of_task_threads;
+	unsigned int number_of_sim_threads;
+
 public:
-	ParallelSimulationManager(unsigned int number_of_sim_threads) : number_of_sim_threads(number_of_sim_threads) {}
+	ParallelSimulationManager(std::size_t number_of_task_threads, unsigned int number_of_sim_threads)
+	    : number_of_task_threads(number_of_task_threads), number_of_sim_threads(number_of_sim_threads)
+	{
+	}
 
 	/// Creates and initiates a new simulation task based on the given configuration.
 	std::shared_ptr<SimulationTask<TResult>> CreateSimulation(
@@ -78,11 +78,35 @@ public:
 	{
 		// Build a simulator.
 		auto sim = SimulatorBuilder::Build(configuration, log, number_of_sim_threads);
-		return std::make_shared<ParallelSimulationTask<TResult>>(sim, args...);
+		auto id = configuration.travel_model->GetRegionId();
+		auto task = std::make_shared<SequentialSimulationTask<TResult, ParallelTaskCommunicator>>(
+		    sim, ParallelTaskCommunicator(id, this), args...);
+		tasks[id] = task;
+		comm_data.MarkReady(id);
+		return task;
 	}
 
-private:
-	unsigned int number_of_sim_threads;
+	/// Waits for all tasks to complete.
+	void WaitAll() final override
+	{
+		// Start 'number_of_task_threads' threads.
+		std::vector<std::thread> threads;
+		for (std::size_t i = 0; i < number_of_task_threads; i++) {
+			threads.emplace_back([this]() {
+				RegionId ready_id;
+				while (TryPopReadyAtomic(ready_id)) {
+					auto task = tasks[ready_id];
+					if (!task->IsDone()) {
+						task->Step();
+					}
+				}
+			});
+		}
+		// Wait for all the threads to complete.
+		for (auto& t : threads) {
+			t.join();
+		}
+	}
 };
 
 } // namespace

--- a/src/main/cpp/multiregion/ParallelSimulationManager.h
+++ b/src/main/cpp/multiregion/ParallelSimulationManager.h
@@ -9,8 +9,8 @@
 #include <memory>
 #include <mutex>
 #include <thread>
-#include <omp.h>
 #include <spdlog/spdlog.h>
+#include "multiregion/LocalSimulationTask.h"
 #include "multiregion/SequentialSimulationManager.h"
 #include "multiregion/SimulationManager.h"
 #include "sim/Simulator.h"
@@ -59,8 +59,7 @@ private:
 	}
 
 	TaskCommunicationData comm_data;
-	std::unordered_map<RegionId, std::shared_ptr<SequentialSimulationTask<TResult, ParallelTaskCommunicator>>>
-	    tasks;
+	std::unordered_map<RegionId, std::shared_ptr<LocalSimulationTask<TResult, ParallelTaskCommunicator>>> tasks;
 	std::mutex comm_mutex;
 	std::size_t number_of_task_threads;
 	unsigned int number_of_sim_threads;
@@ -79,7 +78,7 @@ public:
 		// Build a simulator.
 		auto sim = SimulatorBuilder::Build(configuration, log, number_of_sim_threads);
 		auto id = configuration.travel_model->GetRegionId();
-		auto task = std::make_shared<SequentialSimulationTask<TResult, ParallelTaskCommunicator>>(
+		auto task = std::make_shared<LocalSimulationTask<TResult, ParallelTaskCommunicator>>(
 		    sim, ParallelTaskCommunicator(id, this), args...);
 		tasks[id] = task;
 		comm_data.MarkReady(id);

--- a/src/main/cpp/multiregion/ParallelSimulationManager.h
+++ b/src/main/cpp/multiregion/ParallelSimulationManager.h
@@ -55,7 +55,11 @@ private:
 	bool TryPopReadyAtomic(RegionId& id)
 	{
 		std::lock_guard<std::mutex> lock(comm_mutex);
-		return comm_data.TryPopReady(id);
+		auto success = comm_data.TryPopReady(id);
+		if (success) {
+			comm_data.ResetDependencies(id, tasks[id]->GetConnectedRegions());
+		}
+		return success;
 	}
 
 	TaskCommunicationData comm_data;

--- a/src/main/cpp/multiregion/ParallelSimulationManager.h
+++ b/src/main/cpp/multiregion/ParallelSimulationManager.h
@@ -52,7 +52,7 @@ public:
 	}
 
 	/// Applies the given aggregation function to this simulation task's population.
-	boost::any AggregateAny(std::function<boost::any(const Population&)> apply) final override
+	boost::any AggregateAny(std::function<boost::any(const PopulationRef&)> apply) final override
 	{
 		return sequential_task.AggregateAny(apply);
 	}

--- a/src/main/cpp/multiregion/ParallelSimulationManager.h
+++ b/src/main/cpp/multiregion/ParallelSimulationManager.h
@@ -98,11 +98,11 @@ public:
 		std::vector<std::thread> threads;
 		for (std::size_t i = 0; i < number_of_task_threads; i++) {
 			threads.emplace_back([this]() {
-				// We will leave at least one thread running until the number of
-				// active tasks reaches zero.
+				// We will leave at least one thread running until the number of active tasks reaches
+				// zero.
 				while (active_task_count > 0) {
-					// Acquire a lock, so we don't get weird race conditions like popping
-					// the same task twice.
+					// Acquire a lock, so we don't get weird race conditions like popping the same
+					// task twice.
 					comm_mutex.lock();
 
 					// Try to pop a task that's ready to perform a time step.
@@ -110,16 +110,18 @@ public:
 					if (TryPopReady(ready_id)) {
 						auto task = tasks[ready_id];
 						if (task->IsDone()) {
-							// This task's done. We ought to decrement the active task counter
-							// and we can also consider ending this thread.
+							// This task's done. We ought to decrement the active task
+							// counter and we can also consider ending this thread.
 							auto count = --active_task_count;
 							comm_mutex.unlock();
 							if (count < number_of_task_threads) {
-								// End this thread of execution. We don't need it anymore.
+								// End this thread of execution. We don't need it
+								// anymore.
 								break;
 							}
 						} else {
-							// Have the task perform a single step.
+							// Have the task perform a single step. Release the
+							// communication lock early so other threads can proceed.
 							comm_mutex.unlock();
 							task->Step();
 						}

--- a/src/main/cpp/multiregion/SequentialSimulationManager.h
+++ b/src/main/cpp/multiregion/SequentialSimulationManager.h
@@ -23,9 +23,12 @@ namespace multiregion {
 class TaskCommunicationBuffer final
 {
 public:
-	/// Tells if this communication buffer is ready for a pull operation
-	/// by checking if all of its dependencies have been satisfied.
+	/// Tells if this communication buffer is ready for a pull operation by checking if all of its dependencies have
+	/// been satisfied.
 	bool IsReady() const { return unsatisfied_dependencies.size() == 0; }
+
+	/// Gets the communication buffer's phase, i.e., the simulation day that will be pulled next.
+	std::size_t GetPhase() const { return phase; }
 
 	/// Satisfied the given dependency.
 	void SatisfyDependency(RegionId dependency) { unsatisfied_dependencies.erase(dependency); }
@@ -33,20 +36,24 @@ public:
 	/// Pulls the data from this buffer.
 	SimulationStepInput Pull()
 	{
-		SimulationStepInput result = std::move(pull_buffer);
-		pull_buffer.visitors.clear();
-		pull_buffer.expatriates.clear();
+		SimulationStepInput result = std::move(pull_buffers[phase]);
+		pull_buffers.erase(phase);
+		phase++;
 		return std::move(result);
 	}
 
 	/// Pushes a visitor from the given region into this buffer.
-	void PushVisitor(RegionId source_region_id, const OutgoingVisitor& visitor)
+	void PushVisitor(std::size_t source_region_phase, RegionId source_region_id, const OutgoingVisitor& visitor)
 	{
-		pull_buffer.visitors.emplace_back(visitor.person, source_region_id, visitor.return_day);
+		pull_buffers[source_region_phase].visitors.emplace_back(
+		    visitor.person, source_region_id, visitor.return_day);
 	}
 
-	/// Pushes an expatriate from the given region into.
-	void PushExpatriate(const Person& expatriate) { pull_buffer.expatriates.emplace_back(expatriate); }
+	/// Pushes an expatriate from the given region into this buffer.
+	void PushExpatriate(std::size_t source_region_phase, const Person& expatriate)
+	{
+		pull_buffers[source_region_phase].expatriates.emplace_back(expatriate);
+	}
 
 	/// Sets this buffer's dependencies to the given set of dependencies.
 	void ResetDependencies(const std::unordered_set<RegionId>& new_unsatisfied_dependencies)
@@ -56,7 +63,10 @@ public:
 
 private:
 	/// The task's next pull result, which is mutable.
-	SimulationStepInput pull_buffer;
+	std::unordered_map<std::size_t, SimulationStepInput> pull_buffers;
+
+	/// The task's current phase, i.e., the simulation day that will be pulled next.
+	std::size_t phase;
 
 	/// The set of all task dependencies that have not been satisfied yet.
 	std::unordered_set<RegionId> unsatisfied_dependencies;
@@ -87,11 +97,12 @@ public:
 	/// Pushes output data for the task with the given id and dependencies.
 	void Push(RegionId id, const std::unordered_set<RegionId>& dependencies, const SimulationStepOutput& data)
 	{
+		auto phase = buffers[id].GetPhase();
 		for (const auto& outgoing_visitor : data.visitors) {
-			buffers[outgoing_visitor.visited_region].PushVisitor(id, outgoing_visitor);
+			buffers[outgoing_visitor.visited_region].PushVisitor(phase, id, outgoing_visitor);
 		}
 		for (const auto& returning_expatriate : data.expatriates) {
-			buffers[returning_expatriate.visited_region].PushExpatriate(returning_expatriate.person);
+			buffers[returning_expatriate.visited_region].PushExpatriate(phase, returning_expatriate.person);
 		}
 		for (const auto& dep : dependencies) {
 			auto& buf = buffers[dep];

--- a/src/main/cpp/multiregion/SequentialSimulationManager.h
+++ b/src/main/cpp/multiregion/SequentialSimulationManager.h
@@ -158,7 +158,7 @@ public:
 			auto& buf = buffers[dep];
 			buf.SatisfyDependency(id);
 			if (buf.IsReady()) {
-				ready_tasks.insert(dep);
+				MarkReady(dep);
 			}
 		}
 		if (buffers[id].IsReady()) {

--- a/src/main/cpp/multiregion/SequentialSimulationManager.h
+++ b/src/main/cpp/multiregion/SequentialSimulationManager.h
@@ -50,9 +50,9 @@ public:
 	void Wait() final override { Start(); }
 
 	/// Applies the given aggregation function to this simulation task's population.
-	boost::any AggregateAny(std::function<boost::any(const Population&)> apply) final override
+	boost::any AggregateAny(std::function<boost::any(const PopulationRef&)> apply) final override
 	{
-		return apply(*sim->GetPopulation());
+		return apply(sim->GetPopulation());
 	}
 
 private:

--- a/src/main/cpp/multiregion/SimulationManager.h
+++ b/src/main/cpp/multiregion/SimulationManager.h
@@ -44,13 +44,13 @@ public:
 	/// Gets the simulation task's population.
 	size_t GetPopulationSize()
 	{
-		return Aggregate<size_t>([](const PopulationRef& pop) -> size_t { return pop->size(); });
+		return Aggregate<size_t>([](const PopulationRef& pop) -> std::size_t { return pop->size(); });
 	}
 
 	/// Gets the number of people that are infected in the simulation task's population.
 	size_t GetInfectedCount()
 	{
-		return Aggregate<size_t>([](const PopulationRef& pop) -> size_t { return pop->get_infected_count(); });
+		return Aggregate<size_t>([](const PopulationRef& pop) -> std::size_t { return pop->get_infected_count(); });
 	}
 
 	/// Gets this simulation task's population.

--- a/src/main/cpp/multiregion/SimulationManager.h
+++ b/src/main/cpp/multiregion/SimulationManager.h
@@ -35,32 +35,32 @@ public:
 
 	/// Applies the given aggregation function to this simulation task's population.
 	template <typename TAggregate>
-	TAggregate Aggregate(TAggregate apply(const Population&))
+	TAggregate Aggregate(TAggregate apply(const PopulationRef&))
 	{
 		return boost::any_cast<TAggregate>(
-		    AggregateAny([apply](const Population& pop) -> boost::any { return boost::any(apply(pop)); }));
+		    AggregateAny([apply](const PopulationRef& pop) -> boost::any { return boost::any(apply(pop)); }));
 	}
 
 	/// Gets the simulation task's population.
 	size_t GetPopulationSize()
 	{
-		return Aggregate<size_t>([](const Population& pop) -> size_t { return pop.size(); });
+		return Aggregate<size_t>([](const PopulationRef& pop) -> size_t { return pop->size(); });
 	}
 
 	/// Gets the number of people that are infected in the simulation task's population.
 	size_t GetInfectedCount()
 	{
-		return Aggregate<size_t>([](const Population& pop) -> size_t { return pop.GetInfectedCount(); });
+		return Aggregate<size_t>([](const PopulationRef& pop) -> size_t { return pop->GetInfectedCount(); });
 	}
 
 	/// Gets this simulation task's population.
-	Population GetPopulation()
+	PopulationRef GetPopulation()
 	{
-		return Aggregate<Population>([](const Population& pop) -> Population { return pop; });
+		return Aggregate<PopulationRef>([](const PopulationRef& pop) -> PopulationRef { return pop; });
 	}
 
 	/// Applies the given aggregation function to this simulation task's population.
-	virtual boost::any AggregateAny(std::function<boost::any(const Population&)>) = 0;
+	virtual boost::any AggregateAny(std::function<boost::any(const PopulationRef&)>) = 0;
 };
 
 /**

--- a/src/main/cpp/multiregion/SimulationManager.h
+++ b/src/main/cpp/multiregion/SimulationManager.h
@@ -50,7 +50,7 @@ public:
 	/// Gets the number of people that are infected in the simulation task's population.
 	size_t GetInfectedCount()
 	{
-		return Aggregate<size_t>([](const PopulationRef& pop) -> size_t { return pop->GetInfectedCount(); });
+		return Aggregate<size_t>([](const PopulationRef& pop) -> size_t { return pop->get_infected_count(); });
 	}
 
 	/// Gets this simulation task's population.

--- a/src/main/cpp/multiregion/SimulationManager.h
+++ b/src/main/cpp/multiregion/SimulationManager.h
@@ -27,12 +27,6 @@ public:
 	/// Fetches this simulation task's result.
 	virtual TResult GetResult() = 0;
 
-	/// Starts this simulation.
-	virtual void Start() = 0;
-
-	/// Waits for this simulation to complete.
-	virtual void Wait() = 0;
-
 	/// Applies the given aggregation function to this simulation task's population.
 	template <typename TAggregate>
 	TAggregate Aggregate(TAggregate apply(const PopulationRef&))
@@ -73,6 +67,9 @@ struct SimulationManager
 	virtual std::shared_ptr<SimulationTask<TResult>> CreateSimulation(
 	    const SingleSimulationConfig& configuration, const std::shared_ptr<spdlog::logger>& log,
 	    TInitialResultArgs... args) = 0;
+
+	/// Waits for all simulation tasks to complete.
+	virtual void WaitAll() = 0;
 };
 
 } // namespace

--- a/src/main/cpp/multiregion/TravelModel.cpp
+++ b/src/main/cpp/multiregion/TravelModel.cpp
@@ -30,7 +30,7 @@ RegionTravel::RegionTravel(
 
 		for (const auto& route : airport->routes) {
 			if (route.target->region_id == region_id || airport->region_id == region_id) {
-				connected_regions.insert(airport->region_id);
+				connected_regions.insert(route.target->region_id);
 			}
 		}
 	}

--- a/src/main/cpp/multiregion/TravelModel.cpp
+++ b/src/main/cpp/multiregion/TravelModel.cpp
@@ -25,10 +25,11 @@ RegionTravel::RegionTravel(
 	for (const auto& airport : *all_airports) {
 		if (airport->region_id == region_id) {
 			local_airports.push_back(airport);
-		} else {
-			for (const auto& route : airport->routes) {
-				if (route.target->region_id == region_id)
-					regions_with_incoming_routes.insert(airport->region_id);
+		}
+
+		for (const auto& route : airport->routes) {
+			if (route.target->region_id == region_id || airport->region_id == region_id) {
+				connected_regions.insert(airport->region_id);
 			}
 		}
 	}

--- a/src/main/cpp/multiregion/TravelModel.h
+++ b/src/main/cpp/multiregion/TravelModel.h
@@ -75,10 +75,10 @@ public:
 	/// Gets the fraction of people in the region who travel by plane on any given day.
 	double GetTravelFraction() const { return travel_fraction; }
 
-	/// Gets the minimal duration of a trip abroad.
+	/// Gets the minimal duration of a trip abroad, in days.
 	std::size_t GetMinTravelDuration() const { return min_travel_duration; }
 
-	/// Gets the maximal duration of a trip abroad.
+	/// Gets the maximal duration of a trip abroad, in days.
 	std::size_t GetMaxTravelDuration() const { return max_travel_duration; }
 
 	/// Gets a list of all airports.

--- a/src/main/cpp/multiregion/TravelModel.h
+++ b/src/main/cpp/multiregion/TravelModel.h
@@ -14,7 +14,7 @@
 namespace stride {
 namespace multiregion {
 
-using RegionId = size_t;
+using RegionId = std::size_t;
 
 struct Airport;
 using AirportRef = std::shared_ptr<const Airport>;

--- a/src/main/cpp/multiregion/TravelModel.h
+++ b/src/main/cpp/multiregion/TravelModel.h
@@ -63,6 +63,7 @@ public:
 	/// Creates a travel model for a single region.
 	RegionTravel(
 	    RegionId region_id, const std::string& region_population_path, double travel_fraction,
+	    std::size_t min_travel_duration, std::size_t max_travel_duration,
 	    const std::shared_ptr<const std::vector<AirportRef>>& all_airports);
 
 	/// Gets the region id for the region this data structure represents.
@@ -74,6 +75,12 @@ public:
 	/// Gets the fraction of people in the region who travel by plane on any given day.
 	double GetTravelFraction() const { return travel_fraction; }
 
+	/// Gets the minimal duration of a trip abroad.
+	std::size_t GetMinTravelDuration() const { return min_travel_duration; }
+
+	/// Gets the maximal duration of a trip abroad.
+	std::size_t GetMaxTravelDuration() const { return max_travel_duration; }
+
 	/// Gets a list of all airports.
 	const std::vector<AirportRef>& GetAllAirports() const { return *all_airports; }
 
@@ -82,10 +89,7 @@ public:
 
 	/// Gets the set of region ids for regions that are connected with this region
 	/// by an air route.
-	const std::unordered_set<RegionId>& GetConnectedRegions() const
-	{
-		return connected_regions;
-	}
+	const std::unordered_set<RegionId>& GetConnectedRegions() const { return connected_regions; }
 
 	/// Parses a ptree that contains a vector of travel information for regions.
 	/// The identifier for the first region can be specified. All regions are assigned
@@ -98,6 +102,8 @@ private:
 	RegionId region_id;
 	std::string region_population_path;
 	double travel_fraction;
+	std::size_t min_travel_duration;
+	std::size_t max_travel_duration;
 	std::shared_ptr<const std::vector<AirportRef>> all_airports;
 	std::vector<AirportRef> local_airports;
 	std::unordered_set<RegionId> connected_regions;

--- a/src/main/cpp/multiregion/TravelModel.h
+++ b/src/main/cpp/multiregion/TravelModel.h
@@ -80,11 +80,11 @@ public:
 	/// Gets a list of airports in the current region.
 	const std::vector<AirportRef>& GetLocalAirports() const { return local_airports; }
 
-	/// Gets the set of region ids for regions that have at least one air
-	/// route which targets a local airport.
-	const std::unordered_set<RegionId>& GetRegionsWithIncomingRoutes() const
+	/// Gets the set of region ids for regions that are connected with this region
+	/// by an air route.
+	const std::unordered_set<RegionId>& GetConnectedRegions() const
 	{
-		return regions_with_incoming_routes;
+		return connected_regions;
 	}
 
 	/// Parses a ptree that contains a vector of travel information for regions.
@@ -100,7 +100,7 @@ private:
 	double travel_fraction;
 	std::shared_ptr<const std::vector<AirportRef>> all_airports;
 	std::vector<AirportRef> local_airports;
-	std::unordered_set<RegionId> regions_with_incoming_routes;
+	std::unordered_set<RegionId> connected_regions;
 };
 
 } // namespace

--- a/src/main/cpp/multiregion/Visitor.h
+++ b/src/main/cpp/multiregion/Visitor.h
@@ -1,0 +1,57 @@
+#ifndef VISITOR_H_INCLUDED
+#define VISITOR_H_INCLUDED
+
+#include <unordered_map>
+#include "multiregion/TravelModel.h"
+#include "pop/Person.h"
+
+/**
+ * @file Defines data structures that keep track of a region's visitors and expatriates.
+ */
+
+namespace stride {
+namespace multiregion {
+
+/**
+ * Represents an outgoing visitor: a person who visits another region.
+ */
+struct OutgoingVisitor final
+{
+	OutgoingVisitor(const Person& person, RegionId visited_region, std::size_t return_day)
+	    : person(person), visited_region(visited_region), return_day(return_day)
+	{
+	}
+
+	/// The person who is visiting another region.
+	Person person;
+
+	/// The region this visitor is visiting.
+	RegionId visited_region;
+
+	/// The index of the day on which this visitor's return trip is scheduled.
+	std::size_t return_day;
+};
+
+/**
+ * Represents an incoming visitor: a person who is visiting from another region.
+ */
+struct IncomingVisitor final
+{
+	IncomingVisitor(const Person& person, RegionId home_region, std::size_t return_day)
+	    : person(person), home_region(home_region), return_day(return_day)
+	{
+	}
+
+	/// The person who is visiting another region.
+	Person person;
+
+	/// The region this visitor is visiting from.
+	RegionId home_region;
+
+	/// The index of the day on which this visitor's return trip is scheduled.
+	std::size_t return_day;
+};
+}
+}
+
+#endif

--- a/src/main/cpp/multiregion/Visitor.h
+++ b/src/main/cpp/multiregion/Visitor.h
@@ -51,6 +51,29 @@ struct IncomingVisitor final
 	/// The index of the day on which this visitor's return trip is scheduled.
 	std::size_t return_day;
 };
+
+/// The input for a single step in the simulation and the result
+/// of a pull operation.
+struct SimulationStepInput final
+{
+	/// The list of all incoming visitors.
+	std::vector<IncomingVisitor> visitors;
+
+	/// The list of all returning expatriates.
+	std::vector<Person> expatriates;
+};
+
+/// The output for a single step in the simulation and the result
+/// of a push operation.
+struct SimulationStepOutput final
+{
+	/// The list of all outgoing visitors.
+	std::vector<OutgoingVisitor> visitors;
+
+	/// The list of all returning expatriates.
+	std::vector<OutgoingVisitor> expatriates;
+};
+
 }
 }
 

--- a/src/main/cpp/multiregion/Visitor.h
+++ b/src/main/cpp/multiregion/Visitor.h
@@ -1,7 +1,7 @@
 #ifndef VISITOR_H_INCLUDED
 #define VISITOR_H_INCLUDED
 
-#include <unordered_map>
+#include <vector>
 #include "multiregion/TravelModel.h"
 #include "pop/Person.h"
 
@@ -73,7 +73,6 @@ struct SimulationStepOutput final
 	/// The list of all returning expatriates.
 	std::vector<OutgoingVisitor> expatriates;
 };
-
 }
 }
 

--- a/src/main/cpp/multiregion/VisitorJournal.h
+++ b/src/main/cpp/multiregion/VisitorJournal.h
@@ -17,7 +17,7 @@ namespace multiregion {
  * person's id in their home region and the second is their id in the region they're
  * visiting.
  */
-struct Visitor final
+struct VisitorId final
 {
 	/// The visitor's id in their home region.
 	PersonId home_id;
@@ -54,13 +54,13 @@ class VisitorJournal final
 {
 public:
 	/// Adds the given visitor to this journal.
-	void add_visitor(Visitor visitor, RegionId home_region_id, std::size_t return_day)
+	void add_visitor(VisitorId visitor, RegionId home_region_id, std::size_t return_day)
 	{
 		visitors[return_day][home_region_id].push_back(visitor);
 	}
 
 	/// Extracts all visitors that were scheduled to return on the given day.
-	std::unordered_map<RegionId, std::vector<Visitor>> extract_visitors(std::size_t return_day)
+	std::unordered_map<RegionId, std::vector<VisitorId>> extract_visitors(std::size_t return_day)
 	{
 		auto result = std::move(visitors[return_day]);
 		visitors.erase(return_day);
@@ -70,7 +70,7 @@ public:
 private:
 	/// A dictionary of visitors, grouped by the day of their return trip and the region
 	/// that sent them.
-	std::unordered_map<std::size_t, std::unordered_map<RegionId, std::vector<Visitor>>> visitors;
+	std::unordered_map<std::size_t, std::unordered_map<RegionId, std::vector<VisitorId>>> visitors;
 };
 }
 }

--- a/src/main/cpp/multiregion/VisitorJournal.h
+++ b/src/main/cpp/multiregion/VisitorJournal.h
@@ -1,0 +1,78 @@
+#ifndef VISITOR_JOURNAL_H_INCLUDED
+#define VISITOR_JOURNAL_H_INCLUDED
+
+#include <unordered_map>
+#include "multiregion/TravelModel.h"
+#include "pop/Person.h"
+
+/**
+ * @file Defines data structures that keep track of a region's visitors and expatriates.
+ */
+
+namespace stride {
+namespace multiregion {
+
+/**
+ * Represents a visitor to a region: a pair of ids of which the first represents the
+ * person's id in their home region and the second is their id in the region they're
+ * visiting.
+ */
+struct Visitor final
+{
+	/// The visitor's id in their home region.
+	PersonId home_id;
+
+	/// The visitor's id in the region they're visiting.
+	PersonId visitor_id;
+};
+
+/**
+ * Keeps track of people who are currently outside of their home region.
+ */
+class ExpatriateJournal final
+{
+	/// Adds an expatriate to this journal.
+	void add_expatriate(Person&& person) { expatriates.emplace(person.GetId(), person); }
+
+	/// Extracts the expatriate with the given id.
+	Person extract_expatriate(PersonId id)
+	{
+		auto result = std::move(expatriates.find(id)->second);
+		expatriates.erase(id);
+		return std::move(result);
+	}
+
+private:
+	/// A dictionary that maps expatriate person ids to personal information.
+	std::unordered_map<PersonId, Person> expatriates;
+};
+
+/**
+ * Records all visitors to a region.
+ */
+class VisitorJournal final
+{
+public:
+	/// Adds the given visitor to this journal.
+	void add_visitor(Visitor visitor, RegionId home_region_id, std::size_t return_day)
+	{
+		visitors[return_day][home_region_id].push_back(visitor);
+	}
+
+	/// Extracts all visitors that were scheduled to return on the given day.
+	std::unordered_map<RegionId, std::vector<Visitor>> extract_visitors(std::size_t return_day)
+	{
+		auto result = std::move(visitors[return_day]);
+		visitors.erase(return_day);
+		return std::move(result);
+	}
+
+private:
+	/// A dictionary of visitors, grouped by the day of their return trip and the region
+	/// that sent them.
+	std::unordered_map<std::size_t, std::unordered_map<RegionId, std::vector<Visitor>>> visitors;
+};
+}
+}
+
+#endif

--- a/src/main/cpp/multiregion/VisitorJournal.h
+++ b/src/main/cpp/multiregion/VisitorJournal.h
@@ -37,7 +37,7 @@ class ExpatriateJournal final
 {
 public:
 	/// Adds an expatriate to this journal.
-	void add_expatriate(Person&& person)
+	void add_expatriate(const Person& person)
 	{
 		if (expatriates.find(person.GetId()) != expatriates.end()) {
 			FATAL_ERROR(
@@ -53,9 +53,9 @@ public:
 		if (expatriates.find(id) == expatriates.end()) {
 			FATAL_ERROR("no expatriate with id " + std::to_string(id) + ".");
 		}
-		auto result = std::move(expatriates.find(id)->second);
+		auto result = expatriates.find(id)->second;
 		expatriates.erase(id);
-		return std::move(result);
+		return result;
 	}
 
 private:

--- a/src/main/cpp/multiregion/VisitorJournal.h
+++ b/src/main/cpp/multiregion/VisitorJournal.h
@@ -37,7 +37,7 @@ class ExpatriateJournal final
 {
 public:
 	/// Adds an expatriate to this journal.
-	void add_expatriate(const Person& person)
+	void AddExpatriate(const Person& person)
 	{
 		if (expatriates.find(person.GetId()) != expatriates.end()) {
 			FATAL_ERROR(
@@ -48,7 +48,7 @@ public:
 	}
 
 	/// Extracts the expatriate with the given id.
-	Person extract_expatriate(PersonId id)
+	Person ExtractExpatriate(PersonId id)
 	{
 		if (expatriates.find(id) == expatriates.end()) {
 			FATAL_ERROR("no expatriate with id " + std::to_string(id) + ".");
@@ -70,13 +70,13 @@ class VisitorJournal final
 {
 public:
 	/// Tests if the person with the given id is a visitor.
-	bool is_visitor(PersonId id) const { return visitor_ids.find(id) != visitor_ids.end(); }
+	bool IsVisitor(PersonId id) const { return visitor_ids.find(id) != visitor_ids.end(); }
 
 	/// Gets the number of visitors in the journal.
-	std::size_t get_visitor_count() const { return visitor_ids.size(); }
+	std::size_t GetVisitorCount() const { return visitor_ids.size(); }
 
 	/// Adds the given visitor to this journal.
-	void add_visitor(VisitorId visitor, RegionId home_region_id, std::size_t return_day)
+	void AddVisitor(VisitorId visitor, RegionId home_region_id, std::size_t return_day)
 	{
 		if (visitor_ids.find(visitor.visitor_id) != visitor_ids.end()) {
 			FATAL_ERROR(
@@ -88,7 +88,7 @@ public:
 	}
 
 	/// Extracts all visitors that were scheduled to return on the given day.
-	std::unordered_map<RegionId, std::vector<VisitorId>> extract_visitors(std::size_t return_day)
+	std::unordered_map<RegionId, std::vector<VisitorId>> ExtractVisitors(std::size_t return_day)
 	{
 		auto result = std::move(visitors[return_day]);
 		visitors.erase(return_day);

--- a/src/main/cpp/multiregion/VisitorJournal.h
+++ b/src/main/cpp/multiregion/VisitorJournal.h
@@ -72,6 +72,9 @@ public:
 	/// Tests if the person with the given id is a visitor.
 	bool is_visitor(PersonId id) const { return visitor_ids.find(id) != visitor_ids.end(); }
 
+	/// Gets the number of visitors in the journal.
+	std::size_t get_visitor_count() const { return visitor_ids.size(); }
+
 	/// Adds the given visitor to this journal.
 	void add_visitor(VisitorId visitor, RegionId home_region_id, std::size_t return_day)
 	{
@@ -90,7 +93,7 @@ public:
 		auto result = std::move(visitors[return_day]);
 		visitors.erase(return_day);
 		for (const auto& pair : result) {
-			for (auto visitor : pair.second) {
+			for (const auto& visitor : pair.second) {
 				visitor_ids.erase(visitor.visitor_id);
 			}
 		}

--- a/src/main/cpp/multiregion/VisitorJournal.h
+++ b/src/main/cpp/multiregion/VisitorJournal.h
@@ -31,6 +31,7 @@ struct VisitorId final
  */
 class ExpatriateJournal final
 {
+public:
 	/// Adds an expatriate to this journal.
 	void add_expatriate(Person&& person) { expatriates.emplace(person.GetId(), person); }
 

--- a/src/main/cpp/output/PersonFile.cpp
+++ b/src/main/cpp/output/PersonFile.cpp
@@ -52,7 +52,7 @@ void PersonFile::Initialize(const std::string& file)
 			<< "end_infectiousness,start_symptomatic,end_symptomatic" << endl;
 }
 
-void PersonFile::Print(const std::shared_ptr<const Population> population)
+void PersonFile::Print(const PopulationRef& population)
 {
 	for(const auto& p : *population) {
 	        const auto& h = p.GetHealth();

--- a/src/main/cpp/output/PersonFile.h
+++ b/src/main/cpp/output/PersonFile.h
@@ -43,7 +43,7 @@ public:
 	~PersonFile();
 
 	/// Print the given cases with corresponding tag.
-	void Print(const std::shared_ptr<const Population> population);
+	void Print(const PopulationRef& population);
 
 private:
 	/// Generate file name and open the file stream.

--- a/src/main/cpp/pop/Person.cpp
+++ b/src/main/cpp/pop/Person.cpp
@@ -32,6 +32,18 @@ namespace stride {
 
 using namespace std;
 
+unsigned int& Person::GetClusterId(ClusterType cluster_type)
+{
+        switch (cluster_type) {
+                case ClusterType::Household:          return m_household_id;
+                case ClusterType::School:             return m_school_id;
+                case ClusterType::Work:               return m_work_id;
+                case ClusterType::PrimaryCommunity:   return m_primary_community_id;
+                case ClusterType::SecondaryCommunity: return m_secondary_community_id;
+                default: FATAL_ERROR("Should not reach default.");
+        }
+}
+
 unsigned int Person::GetClusterId(ClusterType cluster_type) const
 {
         switch (cluster_type) {

--- a/src/main/cpp/pop/Person.cpp
+++ b/src/main/cpp/pop/Person.cpp
@@ -32,7 +32,7 @@ namespace stride {
 
 using namespace std;
 
-unsigned int& Person::GetClusterId(ClusterType cluster_type)
+unsigned int& PersonData::GetClusterId(ClusterType cluster_type)
 {
         switch (cluster_type) {
                 case ClusterType::Household:          return m_household_id;
@@ -44,7 +44,7 @@ unsigned int& Person::GetClusterId(ClusterType cluster_type)
         }
 }
 
-unsigned int Person::GetClusterId(ClusterType cluster_type) const
+unsigned int PersonData::GetClusterId(ClusterType cluster_type) const
 {
         switch (cluster_type) {
                 case ClusterType::Household:          return m_household_id;
@@ -56,7 +56,7 @@ unsigned int Person::GetClusterId(ClusterType cluster_type) const
         }
 }
 
-bool Person::IsInCluster(ClusterType c) const
+bool PersonData::IsInCluster(ClusterType c) const
 {
         switch(c) {
                 case ClusterType::Household:           return m_at_household;
@@ -68,7 +68,7 @@ bool Person::IsInCluster(ClusterType c) const
         }
 }
 
-void Person::Update(bool is_work_off, bool is_school_off)
+void PersonData::Update(bool is_work_off, bool is_school_off)
 {
         m_health.Update();
 

--- a/src/main/cpp/pop/Person.cpp
+++ b/src/main/cpp/pop/Person.cpp
@@ -10,7 +10,8 @@
  *  You should have received a copy of the GNU General Public License
  *  along with the software. If not, see <http://www.gnu.org/licenses/>.
  *
- *  Copyright 2017, Willem L, Kuylen E, Stijven S & Broeckhove J
+ *  Copyright 2017, Willem L, Kuylen E, Stijven S, Broeckhove J
+ *  Aerts S, De Haes C, Van der Cruysse J & Van Hauwe L
  */
 
 /**
@@ -89,7 +90,7 @@ void PersonData::Update(bool is_work_off, bool is_school_off)
 /// Creates a copy of this person and gives it the given id.
 Person Person::WithId(PersonId new_id) const
 {
-        auto result = *this;
+        auto result = Clone();
         result.m_id = new_id;
         return result;
 }

--- a/src/main/cpp/pop/Person.cpp
+++ b/src/main/cpp/pop/Person.cpp
@@ -25,9 +25,9 @@
 #include "core/ClusterType.h"
 #include "util/Errors.h"
 
+#include <memory>
 #include <stdexcept>
 #include <string>
-#include <memory>
 
 namespace stride {
 
@@ -35,64 +35,82 @@ using namespace std;
 
 unsigned int& PersonData::GetClusterId(ClusterType cluster_type)
 {
-        switch (cluster_type) {
-                case ClusterType::Household:          return m_household_id;
-                case ClusterType::School:             return m_school_id;
-                case ClusterType::Work:               return m_work_id;
-                case ClusterType::PrimaryCommunity:   return m_primary_community_id;
-                case ClusterType::SecondaryCommunity: return m_secondary_community_id;
-                default: FATAL_ERROR("Should not reach default.");
-        }
+	switch (cluster_type) {
+	case ClusterType::Household:
+		return m_household_id;
+	case ClusterType::School:
+		return m_school_id;
+	case ClusterType::Work:
+		return m_work_id;
+	case ClusterType::PrimaryCommunity:
+		return m_primary_community_id;
+	case ClusterType::SecondaryCommunity:
+		return m_secondary_community_id;
+	default:
+		FATAL_ERROR("Should not reach default.");
+	}
 }
 
 unsigned int PersonData::GetClusterId(ClusterType cluster_type) const
 {
-        switch (cluster_type) {
-                case ClusterType::Household:          return m_household_id;
-                case ClusterType::School:             return m_school_id;
-                case ClusterType::Work:               return m_work_id;
-                case ClusterType::PrimaryCommunity:   return m_primary_community_id;
-                case ClusterType::SecondaryCommunity: return m_secondary_community_id;
-                default: FATAL_ERROR("Should not reach default.");
-        }
+	switch (cluster_type) {
+	case ClusterType::Household:
+		return m_household_id;
+	case ClusterType::School:
+		return m_school_id;
+	case ClusterType::Work:
+		return m_work_id;
+	case ClusterType::PrimaryCommunity:
+		return m_primary_community_id;
+	case ClusterType::SecondaryCommunity:
+		return m_secondary_community_id;
+	default:
+		FATAL_ERROR("Should not reach default.");
+	}
 }
 
 bool PersonData::IsInCluster(ClusterType c) const
 {
-        switch(c) {
-                case ClusterType::Household:           return m_at_household;
-                case ClusterType::School:              return m_at_school;
-                case ClusterType::Work:                return m_at_work;
-                case ClusterType::PrimaryCommunity:    return m_at_primary_community;
-                case ClusterType::SecondaryCommunity:  return m_at_secondary_community;
-                default: FATAL_ERROR("Should not reach default.");
-        }
+	switch (c) {
+	case ClusterType::Household:
+		return m_at_household;
+	case ClusterType::School:
+		return m_at_school;
+	case ClusterType::Work:
+		return m_at_work;
+	case ClusterType::PrimaryCommunity:
+		return m_at_primary_community;
+	case ClusterType::SecondaryCommunity:
+		return m_at_secondary_community;
+	default:
+		FATAL_ERROR("Should not reach default.");
+	}
 }
 
 void PersonData::Update(bool is_work_off, bool is_school_off)
 {
-        m_health.Update();
+	m_health.Update();
 
-        // Update presence in clusters.
-        if (is_work_off || (m_age <= MinAdultAge() && is_school_off)) {
-        		m_at_school             = false;
-                m_at_work               = false;
-                m_at_secondary_community = false;
-                m_at_primary_community  = true;
-        } else {
-        		m_at_school             = true;
-        		m_at_work               = true;
-                m_at_secondary_community = true;
-                m_at_primary_community  = false;
-        }
+	// Update presence in clusters.
+	if (is_work_off || (m_age <= MinAdultAge() && is_school_off)) {
+		m_at_school = false;
+		m_at_work = false;
+		m_at_secondary_community = false;
+		m_at_primary_community = true;
+	} else {
+		m_at_school = true;
+		m_at_work = true;
+		m_at_secondary_community = true;
+		m_at_primary_community = false;
+	}
 }
 
 /// Creates a copy of this person and gives it the given id.
 Person Person::WithId(PersonId new_id) const
 {
-        auto result = Clone();
-        result.m_id = new_id;
-        return result;
+	auto result = Clone();
+	result.m_id = new_id;
+	return result;
 }
 
 } // end_of_namespace

--- a/src/main/cpp/pop/Person.cpp
+++ b/src/main/cpp/pop/Person.cpp
@@ -86,4 +86,12 @@ void Person::Update(bool is_work_off, bool is_school_off)
         }
 }
 
+/// Creates a copy of this person and gives it the given id.
+Person Person::WithId(PersonId new_id) const
+{
+        auto result = *this;
+        result.m_id = new_id;
+        return result;
+}
+
 } // end_of_namespace

--- a/src/main/cpp/pop/Person.h
+++ b/src/main/cpp/pop/Person.h
@@ -77,6 +77,9 @@ public:
 	const Health& GetHealth() const { return m_health; }
 
 	/// Get the id.
+	PersonId& GetId() { return m_id; }
+
+	/// Get the id.
 	PersonId GetId() const { return m_id; }
 
 	/// Check if a person is present today in a given cluster

--- a/src/main/cpp/pop/Person.h
+++ b/src/main/cpp/pop/Person.h
@@ -64,6 +64,9 @@ public:
 	/// Get cluster ID of cluster_type
 	unsigned int GetClusterId(ClusterType cluster_type) const;
 
+	/// Get cluster ID of cluster_type
+	unsigned int& GetClusterId(ClusterType cluster_type);
+
 	/// Return person's gender.
 	char GetGender() const { return m_gender; }
 

--- a/src/main/cpp/pop/Person.h
+++ b/src/main/cpp/pop/Person.h
@@ -29,6 +29,8 @@
 
 namespace stride {
 
+using PersonId = unsigned int;
+
 class Calendar;
 enum class ClusterType;
 
@@ -39,8 +41,9 @@ class Person
 {
 public:
 	/// Constructor: set the person data.
-	Person(unsigned int id, double age, unsigned int household_id, unsigned int school_id, unsigned int work_id,
-	       unsigned int primary_community_id, unsigned int secondary_community_id, disease::Fate fate)
+	Person(
+	    PersonId id, double age, unsigned int household_id, unsigned int school_id, unsigned int work_id,
+	    unsigned int primary_community_id, unsigned int secondary_community_id, disease::Fate fate)
 	    : m_id(id), m_age(age), m_gender('M'), m_household_id(household_id), m_school_id(school_id),
 	      m_work_id(work_id), m_primary_community_id(primary_community_id),
 	      m_secondary_community_id(secondary_community_id), m_at_household(true), m_at_school(true),
@@ -68,7 +71,7 @@ public:
 	const Health& GetHealth() const { return m_health; }
 
 	/// Get the id.
-	unsigned int GetId() const { return m_id; }
+	PersonId GetId() const { return m_id; }
 
 	/// Check if a person is present today in a given cluster
 	bool IsInCluster(ClusterType c) const;
@@ -83,7 +86,7 @@ public:
 	void Update(bool is_work_off, bool is_school_off);
 
 private:
-	unsigned int m_id;
+	PersonId m_id;
 	double m_age;
 	char m_gender;
 

--- a/src/main/cpp/pop/Person.h
+++ b/src/main/cpp/pop/Person.h
@@ -12,7 +12,8 @@
  *  You should have received a copy of the GNU General Public License
  *  along with the software. If not, see <http://www.gnu.org/licenses/>.
  *
- *  Copyright 2017, Willem L, Kuylen E, Stijven S & Broeckhove J
+ *  Copyright 2017, Willem L, Kuylen E, Stijven S, Broeckhove J
+ *  Aerts S, De Haes C, Van der Cruysse J & Van Hauwe L
  */
 
 /**
@@ -116,25 +117,13 @@ public:
 	Person(
 	    PersonId id, double age, unsigned int household_id, unsigned int school_id, unsigned int work_id,
 	    unsigned int primary_community_id, unsigned int secondary_community_id, disease::Fate fate)
-	    : m_id(id), m_data(std::make_unique<PersonData>(
+	    : m_id(id), m_data(std::make_shared<PersonData>(
 			    age, household_id, school_id, work_id, primary_community_id, secondary_community_id, fate))
 	{
 	}
 
-	Person(const Person& other) : m_id(other.m_id), m_data(std::make_unique<PersonData>(*other.m_data)) {}
-	Person& operator=(const Person& other)
-	{
-		if (this == &other) {
-			return *this;
-		}
-
-		m_id = other.m_id;
-		m_data = std::make_unique<PersonData>(*other.m_data);
-		return *this;
-	}
-
-	Person(Person&& other) = default;
-	Person& operator=(Person&& other) = default;
+	/// Creates a person from the given id and data.
+	Person(PersonId id, const std::shared_ptr<PersonData>& data) : m_id(id), m_data(data) {}
 
 	/// Checks if this person is equal to the given person.
 	bool operator==(const Person& p) const { return m_id == p.m_id; }
@@ -157,7 +146,10 @@ public:
 	/// Get the id.
 	PersonId GetId() const { return m_id; }
 
-	/// Creates a copy of this person and gives it the given id.
+	/// Creates a deep copy of this person, including its data.
+	Person Clone() const { return Person(m_id, std::make_shared<PersonData>(*m_data)); }
+
+	/// Creates a deep copy of this person and gives it the given id.
 	Person WithId(PersonId new_id) const;
 
 	/// Check if a person is present today in a given cluster
@@ -173,11 +165,11 @@ public:
 	void Update(bool is_work_off, bool is_school_off) const { m_data->Update(is_work_off, is_school_off); }
 
 	/// Gets the data that backs this person.
-	PersonData& GetData() const { return *m_data; }
+	std::shared_ptr<PersonData> GetData() const { return m_data; }
 
 private:
 	PersonId m_id;
-	std::unique_ptr<PersonData> m_data;
+	std::shared_ptr<PersonData> m_data;
 };
 
 } // end_of_namespace

--- a/src/main/cpp/pop/Person.h
+++ b/src/main/cpp/pop/Person.h
@@ -77,10 +77,10 @@ public:
 	const Health& GetHealth() const { return m_health; }
 
 	/// Get the id.
-	PersonId& GetId() { return m_id; }
-
-	/// Get the id.
 	PersonId GetId() const { return m_id; }
+
+	/// Creates a copy of this person and gives it the given id.
+	Person WithId(PersonId new_id) const;
 
 	/// Check if a person is present today in a given cluster
 	bool IsInCluster(ClusterType c) const;

--- a/src/main/cpp/pop/Person.h
+++ b/src/main/cpp/pop/Person.h
@@ -52,8 +52,11 @@ public:
 	{
 	}
 
-	/// Is this person not equal to the given person?
-	bool operator!=(const Person& p) const { return p.m_id != m_id; }
+	/// Checks if this person is equal to the given person.
+	bool operator==(const Person& p) const { return m_id == p.m_id; }
+
+	/// Checks if this person is not equal to the given person.
+	bool operator!=(const Person& p) const { return !(*this == p); }
 
 	/// Get the age.
 	double GetAge() const { return m_age; }
@@ -112,5 +115,19 @@ private:
 };
 
 } // end_of_namespace
+
+namespace std {
+/// An std::hash<T> implementation for Person.
+template <>
+struct hash<stride::Person>
+{
+	typedef stride::Person argument_type;
+	typedef std::size_t result_type;
+	result_type operator()(const argument_type& person) const
+	{
+		return std::hash<stride::PersonId>()(person.GetId());
+	}
+};
+}
 
 #endif // end of include guard

--- a/src/main/cpp/pop/Population.cpp
+++ b/src/main/cpp/pop/Population.cpp
@@ -14,7 +14,7 @@
 
 namespace stride {
 /// Gets a list of pointers to 'count' unique, randomly chosen participants in the population.
-std::vector<Person*> Population::get_random_persons(util::Random& rng, std::size_t count)
+std::vector<Person> Population::get_random_persons(util::Random& rng, std::size_t count)
 {
 	auto max_population_index = size() - 1;
 	std::unordered_map<size_t, std::size_t> random_pick_indices;
@@ -26,11 +26,11 @@ std::vector<Person*> Population::get_random_persons(util::Random& rng, std::size
 		random_pick_indices[pick_index] = i;
 	}
 
-	std::vector<Person*> random_picks(count, nullptr);
+	std::vector<Person> random_picks(count, Person(0, nullptr));
 	size_t i = 0;
-	for (auto& item : people) {
+	for (const auto& pair : people) {
 		if (random_pick_indices.find(i) != random_pick_indices.end()) {
-			random_picks[random_pick_indices[i]] = &item.second;
+			random_picks[random_pick_indices[i]] = Person(pair.first, pair.second);
 		}
 		i++;
 	}
@@ -40,7 +40,7 @@ std::vector<Person*> Population::get_random_persons(util::Random& rng, std::size
 
 /// Gets a list of pointers to 'count' unique, randomly chosen participants in the population
 /// which satisfy the given predicate.
-std::vector<Person*> Population::get_random_persons(
+std::vector<Person> Population::get_random_persons(
     util::Random& rng, std::size_t count, std::function<bool(const Person&)> matches)
 {
 	// This function tries to search as efficiently as possible for people who match
@@ -55,13 +55,13 @@ std::vector<Person*> Population::get_random_persons(
 	// iteration does not find any suitable persons until either the entire population is
 	// sampled and we throw an exception or we find enough matching candidates.
 
-	std::vector<Person*> results;
+	std::vector<Person> results;
 	size_t sample_size = count;
 	while (count > 0) {
 		size_t found = 0;
-		for (auto ptr : get_random_persons(rng, sample_size)) {
-			if (matches(*ptr)) {
-				results.push_back(ptr);
+		for (auto person : get_random_persons(rng, sample_size)) {
+			if (matches(person)) {
+				results.push_back(person);
 				count--;
 				found++;
 			}

--- a/src/main/cpp/pop/Population.cpp
+++ b/src/main/cpp/pop/Population.cpp
@@ -14,10 +14,10 @@
 
 namespace stride {
 /// Gets a list of pointers to 'count' unique, randomly chosen participants in the population.
-std::vector<Person*> Population::get_random_persons(util::Random& rng, size_t count)
+std::vector<Person*> Population::get_random_persons(util::Random& rng, std::size_t count)
 {
 	auto max_population_index = size() - 1;
-	std::unordered_map<size_t, size_t> random_pick_indices;
+	std::unordered_map<size_t, std::size_t> random_pick_indices;
 	for (size_t i = 0; i < count; i++) {
 		size_t pick_index;
 		do {
@@ -41,7 +41,7 @@ std::vector<Person*> Population::get_random_persons(util::Random& rng, size_t co
 /// Gets a list of pointers to 'count' unique, randomly chosen participants in the population
 /// which satisfy the given predicate.
 std::vector<Person*> Population::get_random_persons(
-    util::Random& rng, size_t count, std::function<bool(const Person&)> matches)
+    util::Random& rng, std::size_t count, std::function<bool(const Person&)> matches)
 {
 	// This function tries to search as efficiently as possible for people who match
 	// the given predicate without skewing the distribution too much.

--- a/src/main/cpp/pop/Population.cpp
+++ b/src/main/cpp/pop/Population.cpp
@@ -84,7 +84,7 @@ std::vector<Person*> Population::get_random_persons(
 }
 
 /// Get the cumulative number of cases.
-unsigned int Population::GetInfectedCount() const
+unsigned int Population::get_infected_count() const
 {
 	unsigned int total{0U};
 	for (const auto& p : *this) {

--- a/src/main/cpp/pop/Population.cpp
+++ b/src/main/cpp/pop/Population.cpp
@@ -1,0 +1,96 @@
+#include "Population.h"
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include "Person.h"
+#include "core/Health.h"
+#include "util/Errors.h"
+#include "util/Random.h"
+
+namespace stride {
+/// Gets a list of pointers to 'count' unique, randomly chosen participants in the population.
+std::vector<Person*> Population::get_random_persons(util::Random& rng, size_t count)
+{
+	auto max_population_index = size() - 1;
+	std::unordered_map<size_t, size_t> random_pick_indices;
+	for (size_t i = 0; i < count; i++) {
+		size_t pick_index;
+		do {
+			pick_index = rng(max_population_index);
+		} while (random_pick_indices.find(pick_index) != random_pick_indices.end());
+		random_pick_indices[pick_index] = i;
+	}
+
+	std::vector<Person*> random_picks(count, nullptr);
+	size_t i = 0;
+	for (auto& item : people) {
+		if (random_pick_indices.find(i) != random_pick_indices.end()) {
+			random_picks[random_pick_indices[i]] = &item.second;
+		}
+		i++;
+	}
+
+	return std::move(random_picks);
+}
+
+/// Gets a list of pointers to 'count' unique, randomly chosen participants in the population
+/// which satisfy the given predicate.
+std::vector<Person*> Population::get_random_persons(
+    util::Random& rng, size_t count, std::function<bool(const Person&)> matches)
+{
+	// This function tries to search as efficiently as possible for people who match
+	// the given predicate without skewing the distribution too much.
+	//
+	// The core algorithm used by this function boils down to repeatedly grabbing random
+	// groups of people from the population and testing if they're a match. Note that
+	// there is no bound on how long this can take: if we're SOL, then we'll always end up
+	// picking people who don't match the predicate.
+	//
+	// That issue is compensated for here by growing the sample size exponentially as long as an
+	// iteration does not find any suitable persons until either the entire population is
+	// sampled and we throw an exception or we find enough matching candidates.
+
+	std::vector<Person*> results;
+	size_t sample_size = count;
+	while (count > 0) {
+		size_t found = 0;
+		for (auto ptr : get_random_persons(rng, sample_size)) {
+			if (matches(*ptr)) {
+				results.push_back(ptr);
+				count--;
+				found++;
+			}
+		}
+
+		if (found == 0) {
+			if (sample_size == size()) {
+				FATAL_ERROR(
+				    "Could not find " + std::to_string(count) + " people matching the predicate.");
+			}
+			sample_size *= 2;
+			if (sample_size > size()) {
+				sample_size = size();
+			}
+		} else {
+			sample_size = count;
+		}
+	}
+	return results;
+}
+
+/// Get the cumulative number of cases.
+unsigned int Population::GetInfectedCount() const
+{
+	unsigned int total{0U};
+	for (const auto& p : *this) {
+		const auto& h = p.GetHealth();
+		total += h.IsInfected() || h.IsRecovered();
+	}
+	return total;
+}
+}

--- a/src/main/cpp/pop/Population.h
+++ b/src/main/cpp/pop/Population.h
@@ -41,7 +41,6 @@ private:
 	std::map<PersonId, Person> people;
 	PersonId max_person_id;
 
-private:
 	/// An iterator implementation for Population containers.
 	template <typename TMapIterator>
 	class PopulationIterator

--- a/src/main/cpp/pop/Population.h
+++ b/src/main/cpp/pop/Population.h
@@ -25,8 +25,9 @@
 #include "core/Health.h"
 #include "util/Random.h"
 
-#include <numeric>
 #include <memory>
+#include <numeric>
+#include <unordered_map>
 #include <unordered_set>
 
 namespace stride {
@@ -37,64 +38,125 @@ namespace stride {
 class Population
 {
 private:
-	std::vector<Person> people;
+	std::unordered_map<PersonId, Person> people;
+	PersonId max_person_id;
+
+	template <typename TMapIterator>
+	class PopulationIterator;
 
 public:
+	template <typename TMapIterator>
+	friend void swap(PopulationIterator<TMapIterator>& lhs, PopulationIterator<TMapIterator>& rhs);
+
+private:
+	/// An iterator implementation for Population containers.
+	template <typename TMapIterator>
+	class PopulationIterator
+	{
+	public:
+		typedef TMapIterator map_iterator;
+
+		PopulationIterator(const TMapIterator& map_iterator_val) : map_iterator_val(map_iterator_val) {}
+		PopulationIterator(const PopulationIterator<TMapIterator>&) = default;
+		PopulationIterator<TMapIterator>& operator++()
+		{
+			++map_iterator_val;
+			return *this;
+		}
+		PopulationIterator<TMapIterator>& operator++(int)
+		{
+			map_iterator_val++;
+			return *this;
+		}
+		PopulationIterator<TMapIterator>& operator--()
+		{
+			--map_iterator_val;
+			return *this;
+		}
+		PopulationIterator<TMapIterator>& operator--(int)
+		{
+			map_iterator_val--;
+			return *this;
+		}
+		auto& operator*() { return map_iterator_val->second; }
+		auto& operator*() const { return map_iterator_val->second; }
+		auto operator-> () { return &map_iterator_val->second; }
+		auto operator-> () const { return &map_iterator_val->second; }
+		bool operator==(const PopulationIterator<TMapIterator>& other) const
+		{
+			return map_iterator_val == other.map_iterator_val;
+		}
+		bool operator!=(const PopulationIterator<TMapIterator>& other) const
+		{
+			return map_iterator_val != other.map_iterator_val;
+		}
+
+		template <typename T>
+		friend void swap(PopulationIterator<T>& lhs, PopulationIterator<T>& rhs);
+
+	private:
+		TMapIterator map_iterator_val;
+	};
+
+public:
+	typedef PopulationIterator<decltype(people)::iterator> iterator;
+	typedef PopulationIterator<decltype(people)::const_iterator> const_iterator;
+
 	/// Inserts a new element into the container constructed in-place with the given args.
 	template <typename... TArgs>
 	auto emplace(TArgs&&... args)
 	{
-		return people.emplace_back(args...);
+		Person value(args...);
+		if (value.GetId() > max_person_id)
+			max_person_id = value.GetId();
+
+		return people.emplace(value.GetId(), std::move(value));
 	}
 
 	/// Gets the number of people in this population.
-	auto size() const -> decltype(people.size())
-	{
-		return people.size();
-	}
+	auto size() const -> decltype(people.size()) { return people.size(); }
 
 	/// Creates a mutable iterator positioned at the first person in this population.
-	auto begin() -> decltype(people.begin())
-	{
-		return people.begin();
-	}
+	iterator begin() { return iterator(people.begin()); }
 
 	/// Creates a constant iterator positioned at the first person in this population.
-	auto begin() const -> decltype(people.begin())
-	{
-		return people.begin();
-	}
+	const_iterator begin() const { return const_iterator(people.begin()); }
 
 	/// Creates a mutable iterator positioned just past the last person in this population.
-	auto end() -> decltype(people.end())
-	{
-		return people.end();
-	}
+	iterator end() { return iterator(people.end()); }
 
 	/// Creates a constant iterator positioned just past the last person in this population.
-	auto end() const -> decltype(people.end())
-	{
-		return people.end();
-	}
+	const_iterator end() const { return const_iterator(people.end()); }
 
-	/// Gets a mutable reference to a random person in the population.
-	Person& get_random_person(util::Random& rng)
+	/// Gets a list of pointers to 'count' unique, randomly chosen participants in the population.
+	std::vector<Person*> get_random_persons(util::Random& rng, size_t count)
 	{
 		auto max_population_index = size() - 1;
-		return people[rng(max_population_index)];
-	}
+		std::unordered_set<size_t> random_pick_indices;
+		for (size_t i = 0; i < count; i++) {
+			size_t pick_index;
+			do {
+				pick_index = rng(max_population_index);
+			} while (random_pick_indices.find(pick_index) != random_pick_indices.end());
+			random_pick_indices.insert(pick_index);
+		}
 
-	/// Gets a constant reference to a random person in the population.
-	const Person& get_random_person(util::Random& rng) const
-	{
-		auto max_population_index = size() - 1;
-		return people[rng(max_population_index)];
+		std::vector<Person*> random_picks;
+		size_t i = 0;
+		for (auto& item : people) {
+			if (random_pick_indices.find(i) != random_pick_indices.end()) {
+				random_picks.push_back(&item.second);
+			}
+			i++;
+		}
+
+		return std::move(random_picks);
 	}
 
 	/// Get the cumulative number of cases.
 	unsigned int GetInfectedCount() const
 	{
-		unsigned int total {0U};
+		unsigned int total{0U};
 		for (const auto& p : *this) {
 			const auto& h = p.GetHealth();
 			total += h.IsInfected() || h.IsRecovered();
@@ -103,8 +165,34 @@ public:
 	}
 };
 
+/// Swaps two population iterators.
+template <typename TMapIterator>
+void swap(
+    typename Population::PopulationIterator<TMapIterator>& lhs,
+    typename Population::PopulationIterator<TMapIterator>& rhs)
+{
+	std::swap(lhs.map_iterator, rhs.map_iterator);
+}
+
 using PopulationRef = std::shared_ptr<const Population>;
 
 } // end_of_namespace
+
+namespace std {
+template <>
+struct iterator_traits<stride::Population::iterator>
+{
+	typedef stride::Person value_type;
+	typedef value_type& reference;
+	typedef value_type* pointer;
+};
+template <>
+struct iterator_traits<stride::Population::const_iterator>
+{
+	typedef const stride::Person value_type;
+	typedef value_type& reference;
+	typedef value_type* pointer;
+};
+}
 
 #endif // end of include guard

--- a/src/main/cpp/pop/Population.h
+++ b/src/main/cpp/pop/Population.h
@@ -21,14 +21,14 @@
  * Header file for the core Population class
  */
 
+#include <functional>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <vector>
 #include "Person.h"
 #include "core/Health.h"
 #include "util/Random.h"
-
-#include <memory>
-#include <numeric>
-#include <unordered_map>
-#include <unordered_set>
 
 namespace stride {
 
@@ -38,7 +38,7 @@ namespace stride {
 class Population
 {
 private:
-	std::unordered_map<PersonId, Person> people;
+	std::map<PersonId, Person> people;
 	PersonId max_person_id;
 
 	template <typename TMapIterator>
@@ -129,40 +129,15 @@ public:
 	const_iterator end() const { return const_iterator(people.end()); }
 
 	/// Gets a list of pointers to 'count' unique, randomly chosen participants in the population.
-	std::vector<Person*> get_random_persons(util::Random& rng, size_t count)
-	{
-		auto max_population_index = size() - 1;
-		std::unordered_set<size_t> random_pick_indices;
-		for (size_t i = 0; i < count; i++) {
-			size_t pick_index;
-			do {
-				pick_index = rng(max_population_index);
-			} while (random_pick_indices.find(pick_index) != random_pick_indices.end());
-			random_pick_indices.insert(pick_index);
-		}
+	std::vector<Person*> get_random_persons(util::Random& rng, size_t count);
 
-		std::vector<Person*> random_picks;
-		size_t i = 0;
-		for (auto& item : people) {
-			if (random_pick_indices.find(i) != random_pick_indices.end()) {
-				random_picks.push_back(&item.second);
-			}
-			i++;
-		}
-
-		return std::move(random_picks);
-	}
+	/// Gets a list of pointers to 'count' unique, randomly chosen participants in the population
+	/// which satisfy the given predicate.
+	std::vector<Person*> get_random_persons(
+	    util::Random& rng, size_t count, std::function<bool(const Person&)> matches);
 
 	/// Get the cumulative number of cases.
-	unsigned int GetInfectedCount() const
-	{
-		unsigned int total{0U};
-		for (const auto& p : *this) {
-			const auto& h = p.GetHealth();
-			total += h.IsInfected() || h.IsRecovered();
-		}
-		return total;
-	}
+	unsigned int GetInfectedCount() const;
 };
 
 /// Swaps two population iterators.

--- a/src/main/cpp/pop/Population.h
+++ b/src/main/cpp/pop/Population.h
@@ -120,6 +120,9 @@ public:
 	/// Creates a constant iterator positioned just past the last person in this population.
 	const_iterator end() const { return const_iterator(people.end()); }
 
+	/// Gets the largest id for any person that has ever been in this population.
+	PersonId get_max_id() const { return max_person_id; }
+
 	/// Gets a list of pointers to 'count' unique, randomly chosen participants in the population.
 	std::vector<Person*> get_random_persons(util::Random& rng, std::size_t count);
 

--- a/src/main/cpp/pop/Population.h
+++ b/src/main/cpp/pop/Population.h
@@ -41,9 +41,6 @@ private:
 	std::map<PersonId, Person> people;
 	PersonId max_person_id;
 
-	template <typename TMapIterator>
-	class PopulationIterator;
-
 private:
 	/// An iterator implementation for Population containers.
 	template <typename TMapIterator>

--- a/src/main/cpp/pop/Population.h
+++ b/src/main/cpp/pop/Population.h
@@ -96,13 +96,13 @@ public:
 
 	/// Inserts a new element into the container constructed in-place with the given args.
 	template <typename... TArgs>
-	auto emplace(TArgs&&... args)
+	iterator emplace(TArgs&&... args)
 	{
 		Person value(args...);
 		if (value.GetId() > max_person_id)
 			max_person_id = value.GetId();
 
-		return people.emplace(value.GetId(), std::move(value));
+		return iterator(people.emplace(value.GetId(), std::move(value)).first);
 	}
 
 	/// Gets the number of people in this population.

--- a/src/main/cpp/pop/Population.h
+++ b/src/main/cpp/pop/Population.h
@@ -44,10 +44,6 @@ private:
 	template <typename TMapIterator>
 	class PopulationIterator;
 
-public:
-	template <typename TMapIterator>
-	friend void swap(PopulationIterator<TMapIterator>& lhs, PopulationIterator<TMapIterator>& rhs);
-
 private:
 	/// An iterator implementation for Population containers.
 	template <typename TMapIterator>

--- a/src/main/cpp/pop/Population.h
+++ b/src/main/cpp/pop/Population.h
@@ -29,6 +29,7 @@
 #include "Person.h"
 #include "core/Health.h"
 #include "util/Random.h"
+#include "util/Errors.h"
 
 namespace stride {
 
@@ -102,14 +103,14 @@ public:
 		if (value.GetId() > max_person_id)
 			max_person_id = value.GetId();
 
-		return iterator(people.emplace(value.GetId(), std::move(value)).first);
+		return iterator(people.emplace(value.GetId(), value).first);
 	}
 
 	/// Extracts the person with the given id from this population.
 	Person extract(PersonId id) {
-		auto result = std::move(people.find(id)->second);
+		auto result = people.find(id)->second;
 		people.erase(id);
-		return std::move(result);
+		return result;
 	}
 
 	/// Gets the number of people in this population.

--- a/src/main/cpp/pop/Population.h
+++ b/src/main/cpp/pop/Population.h
@@ -29,7 +29,6 @@
 #include "Person.h"
 #include "core/Health.h"
 #include "util/Random.h"
-#include "util/Errors.h"
 
 namespace stride {
 

--- a/src/main/cpp/pop/Population.h
+++ b/src/main/cpp/pop/Population.h
@@ -41,54 +41,51 @@ private:
 	std::map<PersonId, std::shared_ptr<PersonData>> people;
 	PersonId max_person_id;
 
+public:
 	/// An iterator implementation for Population containers.
-	template <typename TMapIterator>
-	class PopulationIterator
+	class const_iterator final
 	{
 	public:
-		typedef TMapIterator map_iterator;
+		typedef decltype(people)::const_iterator map_iterator;
 
-		PopulationIterator(const TMapIterator& map_iterator_val) : map_iterator_val(map_iterator_val) {}
-		PopulationIterator(const PopulationIterator<TMapIterator>&) = default;
-		PopulationIterator<TMapIterator>& operator++()
+		const_iterator(const map_iterator& map_iterator_val) : map_iterator_val(map_iterator_val) {}
+		const_iterator(const const_iterator&) = default;
+		const_iterator& operator++()
 		{
 			++map_iterator_val;
 			return *this;
 		}
-		PopulationIterator<TMapIterator>& operator++(int)
+		const_iterator& operator++(int)
 		{
 			map_iterator_val++;
 			return *this;
 		}
-		PopulationIterator<TMapIterator>& operator--()
+		const_iterator& operator--()
 		{
 			--map_iterator_val;
 			return *this;
 		}
-		PopulationIterator<TMapIterator>& operator--(int)
+		const_iterator& operator--(int)
 		{
 			map_iterator_val--;
 			return *this;
 		}
 		Person operator*() const { return Person(map_iterator_val->first, map_iterator_val->second); }
-		bool operator==(const PopulationIterator<TMapIterator>& other) const
+		bool operator==(const const_iterator& other) const
 		{
 			return map_iterator_val == other.map_iterator_val;
 		}
-		bool operator!=(const PopulationIterator<TMapIterator>& other) const
+		bool operator!=(const const_iterator& other) const
 		{
 			return map_iterator_val != other.map_iterator_val;
 		}
 
-		template <typename T>
-		friend void swap(PopulationIterator<T>& lhs, PopulationIterator<T>& rhs);
+		friend void swap(const_iterator& lhs, const_iterator& rhs);
 
 	private:
-		TMapIterator map_iterator_val;
+		map_iterator map_iterator_val;
 	};
 
-public:
-	typedef PopulationIterator<decltype(people)::const_iterator> const_iterator;
 	typedef const_iterator iterator;
 
 	/// Inserts a new element into the container constructed in-place with the given args.
@@ -103,7 +100,8 @@ public:
 	}
 
 	/// Extracts the person with the given id from this population.
-	Person extract(PersonId id) {
+	Person extract(PersonId id)
+	{
 		Person result(id, people.find(id)->second);
 		people.erase(id);
 		return result;
@@ -134,12 +132,9 @@ public:
 };
 
 /// Swaps two population iterators.
-template <typename TMapIterator>
-void swap(
-    typename Population::PopulationIterator<TMapIterator>& lhs,
-    typename Population::PopulationIterator<TMapIterator>& rhs)
+inline void swap(typename Population::const_iterator& lhs, typename Population::const_iterator& rhs)
 {
-	std::swap(lhs.map_iterator, rhs.map_iterator);
+	std::swap(lhs.map_iterator_val, rhs.map_iterator_val);
 }
 
 using PopulationRef = std::shared_ptr<const Population>;

--- a/src/main/cpp/pop/Population.h
+++ b/src/main/cpp/pop/Population.h
@@ -129,12 +129,12 @@ public:
 	const_iterator end() const { return const_iterator(people.end()); }
 
 	/// Gets a list of pointers to 'count' unique, randomly chosen participants in the population.
-	std::vector<Person*> get_random_persons(util::Random& rng, size_t count);
+	std::vector<Person*> get_random_persons(util::Random& rng, std::size_t count);
 
 	/// Gets a list of pointers to 'count' unique, randomly chosen participants in the population
 	/// which satisfy the given predicate.
 	std::vector<Person*> get_random_persons(
-	    util::Random& rng, size_t count, std::function<bool(const Person&)> matches);
+	    util::Random& rng, std::size_t count, std::function<bool(const Person&)> matches);
 
 	/// Get the cumulative number of cases.
 	unsigned int get_infected_count() const;

--- a/src/main/cpp/pop/Population.h
+++ b/src/main/cpp/pop/Population.h
@@ -137,7 +137,7 @@ public:
 	    util::Random& rng, size_t count, std::function<bool(const Person&)> matches);
 
 	/// Get the cumulative number of cases.
-	unsigned int GetInfectedCount() const;
+	unsigned int get_infected_count() const;
 };
 
 /// Swaps two population iterators.

--- a/src/main/cpp/pop/Population.h
+++ b/src/main/cpp/pop/Population.h
@@ -12,7 +12,8 @@
  *  You should have received a copy of the GNU General Public License
  *  along with the software. If not, see <http://www.gnu.org/licenses/>.
  *
- *  Copyright 2017, Willem L, Kuylen E, Stijven S & Broeckhove J
+ *  Copyright 2017, Willem L, Kuylen E, Stijven S, Broeckhove J
+ *  Aerts S, De Haes C, Van der Cruysse J & Van Hauwe L
  */
 
 /**
@@ -22,30 +23,84 @@
 
 #include "Person.h"
 #include "core/Health.h"
+#include "util/Random.h"
 
 #include <numeric>
 #include <memory>
-#include <vector>
+#include <unordered_set>
 
 namespace stride {
 
 /**
  * Container for persons in population.
  */
-class Population : public std::vector<Person>
+class Population
 {
+private:
+	std::vector<Person> people;
+
 public:
+	/// Inserts a new element into the container constructed in-place with the given args.
+	template <typename... TArgs>
+	auto emplace(TArgs&&... args)
+	{
+		return people.emplace_back(args...);
+	}
+
+	/// Gets the number of people in this population.
+	auto size() const -> decltype(people.size())
+	{
+		return people.size();
+	}
+
+	/// Creates a mutable iterator positioned at the first person in this population.
+	auto begin() -> decltype(people.begin())
+	{
+		return people.begin();
+	}
+
+	/// Creates a constant iterator positioned at the first person in this population.
+	auto begin() const -> decltype(people.begin())
+	{
+		return people.begin();
+	}
+
+	/// Creates a mutable iterator positioned just past the last person in this population.
+	auto end() -> decltype(people.end())
+	{
+		return people.end();
+	}
+
+	/// Creates a constant iterator positioned just past the last person in this population.
+	auto end() const -> decltype(people.end())
+	{
+		return people.end();
+	}
+
+	/// Gets a mutable reference to a random person in the population.
+	Person& get_random_person(util::Random& rng)
+	{
+		auto max_population_index = size() - 1;
+		return people[rng(max_population_index)];
+	}
+
+	/// Gets a constant reference to a random person in the population.
+	const Person& get_random_person(util::Random& rng) const
+	{
+		auto max_population_index = size() - 1;
+		return people[rng(max_population_index)];
+	}
+
 	/// Get the cumulative number of cases.
 	unsigned int GetInfectedCount() const
 	{
-	        unsigned int total {0U};
+		unsigned int total {0U};
 		for (const auto& p : *this) {
-		        const auto& h = p.GetHealth();
-		        total += h.IsInfected() || h.IsRecovered();
+			const auto& h = p.GetHealth();
+			total += h.IsInfected() || h.IsRecovered();
 		}
 		return total;
 	}
-
 };
 
 using PopulationRef = std::shared_ptr<const Population>;

--- a/src/main/cpp/pop/Population.h
+++ b/src/main/cpp/pop/Population.h
@@ -105,6 +105,13 @@ public:
 		return iterator(people.emplace(value.GetId(), std::move(value)).first);
 	}
 
+	/// Extracts the person with the given id from this population.
+	Person extract(PersonId id) {
+		auto result = std::move(people.find(id)->second);
+		people.erase(id);
+		return std::move(result);
+	}
+
 	/// Gets the number of people in this population.
 	auto size() const -> decltype(people.size()) { return people.size(); }
 

--- a/src/main/cpp/pop/Population.h
+++ b/src/main/cpp/pop/Population.h
@@ -24,6 +24,7 @@
 #include "core/Health.h"
 
 #include <numeric>
+#include <memory>
 #include <vector>
 
 namespace stride {
@@ -46,6 +47,8 @@ public:
 	}
 
 };
+
+using PopulationRef = std::shared_ptr<const Population>;
 
 } // end_of_namespace
 

--- a/src/main/cpp/pop/PopulationBuilder.cpp
+++ b/src/main/cpp/pop/PopulationBuilder.cpp
@@ -137,8 +137,8 @@ shared_ptr<Population> PopulationBuilder::Build(
 		// Obtain 'num_participant' unique participants.
 		auto is_not_participating = [](const Person& p) -> bool { return !p.IsParticipatingInSurvey(); };
 		for (auto pers : population.get_random_persons(rng, num_participants, is_not_participating)) {
-			pers->ParticipateInSurvey();
-			log->info("[PART] {} {} {}", pers->GetId(), pers->GetAge(), pers->GetGender());
+			pers.ParticipateInSurvey();
+			log->info("[PART] {} {} {}", pers.GetId(), pers.GetAge(), pers.GetGender());
 		}
 	}
 
@@ -146,13 +146,13 @@ shared_ptr<Population> PopulationBuilder::Build(
 	unsigned int num_immune = floor(static_cast<double>(population.size()) * immunity_rate);
 	auto is_susceptible = [](const Person& p) -> bool { return p.GetHealth().IsSusceptible(); };
 	for (auto pers : population.get_random_persons(rng, num_immune, is_susceptible)) {
-		pers->GetHealth().SetImmune();
+		pers.GetHealth().SetImmune();
 	}
 
 	// Seed infected persons.
 	unsigned int num_infected = floor(static_cast<double>(population.size()) * seeding_rate);
 	for (auto pers : population.get_random_persons(rng, num_infected, is_susceptible)) {
-		pers->GetHealth().StartInfection();
+		pers.GetHealth().StartInfection();
 	}
 
 	// Done

--- a/src/main/cpp/pop/PopulationBuilder.cpp
+++ b/src/main/cpp/pop/PopulationBuilder.cpp
@@ -132,18 +132,16 @@ shared_ptr<Population> PopulationBuilder::Build(
 	// Set participants in social contact survey.
 	const auto log_level = config.log_config->log_level;
 	if (log_level == LogMode::Contacts) {
-		const unsigned int num_participants = config.common_config->number_of_survey_participants;
+		unsigned int num_participants = config.common_config->number_of_survey_participants;
 
-		// use a while-loop to obtain 'num_participant' unique participants (default sampling is with
-		// replacement)
-		// A for loop will not do because we might draw the same person twice.
-		unsigned int num_samples = 0;
-		while (num_samples < num_participants) {
-			Person& p = population.get_random_person(rng);
-			if (!p.IsParticipatingInSurvey()) {
-				p.ParticipateInSurvey();
-				log->info("[PART] {} {} {}", p.GetId(), p.GetAge(), p.GetGender());
-				num_samples++;
+		// Obtain 'num_participant' unique participants.
+		while (num_participants > 0) {
+			for (auto pers : population.get_random_persons(rng, num_participants)) {
+				if (!pers->IsParticipatingInSurvey()) {
+					pers->ParticipateInSurvey();
+					log->info("[PART] {} {} {}", pers->GetId(), pers->GetAge(), pers->GetGender());
+					num_participants--;
+				}
 			}
 		}
 	}
@@ -151,20 +149,22 @@ shared_ptr<Population> PopulationBuilder::Build(
 	// Set population immunity.
 	unsigned int num_immune = floor(static_cast<double>(population.size()) * immunity_rate);
 	while (num_immune > 0) {
-		Person& p = population.get_random_person(rng);
-		if (p.GetHealth().IsSusceptible()) {
-			p.GetHealth().SetImmune();
-			num_immune--;
+		for (auto pers : population.get_random_persons(rng, num_immune)) {
+			if (pers->GetHealth().IsSusceptible()) {
+				pers->GetHealth().SetImmune();
+				num_immune--;
+			}
 		}
 	}
 
 	// Seed infected persons.
 	unsigned int num_infected = floor(static_cast<double>(population.size()) * seeding_rate);
 	while (num_infected > 0) {
-		Person& p = population.get_random_person(rng);
-		if (p.GetHealth().IsSusceptible()) {
-			p.GetHealth().StartInfection();
-			num_infected--;
+		for (auto pers : population.get_random_persons(rng, num_infected)) {
+			if (pers->GetHealth().IsSusceptible()) {
+				pers->GetHealth().StartInfection();
+				num_infected--;
+			}
 		}
 	}
 

--- a/src/main/cpp/pop/PopulationBuilder.cpp
+++ b/src/main/cpp/pop/PopulationBuilder.cpp
@@ -135,37 +135,24 @@ shared_ptr<Population> PopulationBuilder::Build(
 		unsigned int num_participants = config.common_config->number_of_survey_participants;
 
 		// Obtain 'num_participant' unique participants.
-		while (num_participants > 0) {
-			for (auto pers : population.get_random_persons(rng, num_participants)) {
-				if (!pers->IsParticipatingInSurvey()) {
-					pers->ParticipateInSurvey();
-					log->info("[PART] {} {} {}", pers->GetId(), pers->GetAge(), pers->GetGender());
-					num_participants--;
-				}
-			}
+		auto is_not_participating = [](const Person& p) -> bool { return !p.IsParticipatingInSurvey(); };
+		for (auto pers : population.get_random_persons(rng, num_participants, is_not_participating)) {
+			pers->ParticipateInSurvey();
+			log->info("[PART] {} {} {}", pers->GetId(), pers->GetAge(), pers->GetGender());
 		}
 	}
 
 	// Set population immunity.
 	unsigned int num_immune = floor(static_cast<double>(population.size()) * immunity_rate);
-	while (num_immune > 0) {
-		for (auto pers : population.get_random_persons(rng, num_immune)) {
-			if (pers->GetHealth().IsSusceptible()) {
-				pers->GetHealth().SetImmune();
-				num_immune--;
-			}
-		}
+	auto is_susceptible = [](const Person& p) -> bool { return p.GetHealth().IsSusceptible(); };
+	for (auto pers : population.get_random_persons(rng, num_immune, is_susceptible)) {
+		pers->GetHealth().SetImmune();
 	}
 
 	// Seed infected persons.
 	unsigned int num_infected = floor(static_cast<double>(population.size()) * seeding_rate);
-	while (num_infected > 0) {
-		for (auto pers : population.get_random_persons(rng, num_infected)) {
-			if (pers->GetHealth().IsSusceptible()) {
-				pers->GetHealth().StartInfection();
-				num_infected--;
-			}
-		}
+	for (auto pers : population.get_random_persons(rng, num_infected, is_susceptible)) {
+		pers->GetHealth().StartInfection();
 	}
 
 	// Done

--- a/src/main/cpp/pop/PopulationGenerator.cpp
+++ b/src/main/cpp/pop/PopulationGenerator.cpp
@@ -152,8 +152,8 @@ unsigned int Generator::CommunityID() { return random(num_communities) + 1; }
 
 void Generator::GeneratePerson(Population& population, int age)
 {
-	population.emplace_back(Person(people_generated++, age, household_id, SchoolID(age), WorkID(age), CommunityID(),
-				       CommunityID(), disease.Sample(random)));
+	population.emplace(people_generated++, age, household_id, SchoolID(age), WorkID(age), CommunityID(),
+				       CommunityID(), disease.Sample(random));
 }
 
 bool Generator::FitsModel(const Population& population, bool verbose)

--- a/src/main/cpp/sim/Simulator.cpp
+++ b/src/main/cpp/sim/Simulator.cpp
@@ -98,8 +98,19 @@ void Simulator::UpdateClusters()
         }
 }
 
+void Simulator::AcceptVisitors(const multiregion::SimulationStepInput& input)
+{
+
+}
+
+multiregion::SimulationStepOutput Simulator::ReturnVisitors()
+{
+        return multiregion::SimulationStepOutput();
+}
+
 multiregion::SimulationStepOutput Simulator::TimeStep(const multiregion::SimulationStepInput& input)
 {
+        AcceptVisitors(input);
         shared_ptr<DaysOffInterface> days_off {nullptr};
 
         // Logic where you compute (on the basis of input/config for initial day
@@ -139,6 +150,6 @@ multiregion::SimulationStepOutput Simulator::TimeStep(const multiregion::Simulat
         }
 
         m_calendar->AdvanceDay();
-        return multiregion::SimulationStepOutput();
+        return ReturnVisitors();
 }
 } // end_of_namespace

--- a/src/main/cpp/sim/Simulator.cpp
+++ b/src/main/cpp/sim/Simulator.cpp
@@ -125,7 +125,20 @@ void Simulator::AddPersonToClusters(Person& person)
 
 void Simulator::AcceptVisitors(const multiregion::SimulationStepInput& input)
 {
+        for (const auto& returning_expat : input.expatriates) {
+                // Return the expatriate to this region's population.
+                auto& returned_expat = *m_population->emplace(returning_expat);
+                auto home_expat = m_expatriates.extract_expatriate(returning_expat.GetId());
 
+                // Update the returning expatriate's clusters.
+                for (std::size_t i = 0; i < NumOfClusterTypes(); i++) {
+                        auto cluster_type = static_cast<ClusterType>(i);
+                        returned_expat.GetClusterId(cluster_type) = home_expat.GetClusterId(cluster_type);
+                }
+
+                // Add the returning expatriate to their clusters.
+                AddPersonToClusters(returned_expat);
+        }
 }
 
 multiregion::SimulationStepOutput Simulator::ReturnVisitors()

--- a/src/main/cpp/sim/Simulator.cpp
+++ b/src/main/cpp/sim/Simulator.cpp
@@ -27,13 +27,13 @@
 #include "core/ClusterType.h"
 #include "core/Infector.h"
 #include "core/LogMode.h"
-#include "pop/Population.h"
 #include "multiregion/Visitor.h"
+#include "pop/Population.h"
 
-#include <spdlog/spdlog.h>
+#include <memory>
 #include <boost/property_tree/ptree.hpp>
 #include <omp.h>
-#include <memory>
+#include <spdlog/spdlog.h>
 
 namespace stride {
 
@@ -42,292 +42,294 @@ using namespace boost::property_tree;
 using namespace stride::util;
 
 Simulator::Simulator()
-        : m_config(), m_num_threads(1U), m_log_level(LogMode::Null), m_population(nullptr),
-          m_disease_profile(), m_track_index_case(false)
+    : m_config(), m_num_threads(1U), m_log_level(LogMode::Null), m_population(nullptr), m_disease_profile(),
+      m_track_index_case(false)
 {
 }
 
-const shared_ptr<const Population> Simulator::GetPopulation() const
-{
-        return m_population;
-}
+const shared_ptr<const Population> Simulator::GetPopulation() const { return m_population; }
 
-SingleSimulationConfig Simulator::GetConfiguration() const
-{
-        return m_config;
-}
+SingleSimulationConfig Simulator::GetConfiguration() const { return m_config; }
 
-void Simulator::SetTrackIndexCase(bool track_index_case)
-{
-        m_track_index_case = track_index_case;
-}
+void Simulator::SetTrackIndexCase(bool track_index_case) { m_track_index_case = track_index_case; }
 
-template<LogMode log_level, bool track_index_case>
+template <LogMode log_level, bool track_index_case>
 void Simulator::UpdateClusters()
 {
-        auto log = m_log;
+	auto log = m_log;
 
-        #pragma omp parallel num_threads(m_num_threads)
-        {
-                const unsigned int thread = omp_get_thread_num();
+#pragma omp parallel num_threads(m_num_threads)
+	{
+		const unsigned int thread = omp_get_thread_num();
 
-                #pragma omp for schedule(runtime)
-                for (size_t i = 0; i < m_households.size(); i++) {
-                        Infector<log_level, track_index_case>::Execute(
-                                m_households[i], m_disease_profile, m_rng_handler[thread], m_calendar, log);
-                }
-                #pragma omp for schedule(runtime)
-                for (size_t i = 0; i < m_school_clusters.size(); i++) {
-                        Infector<log_level, track_index_case>::Execute(
-                                m_school_clusters[i], m_disease_profile, m_rng_handler[thread], m_calendar, log);
-                }
-                #pragma omp for schedule(runtime)
-                for (size_t i = 0; i < m_work_clusters.size(); i++) {
-                        Infector<log_level, track_index_case>::Execute(
-                                m_work_clusters[i], m_disease_profile, m_rng_handler[thread], m_calendar, log);
-                }
-                #pragma omp for schedule(runtime)
-                for (size_t i = 0; i < m_primary_community.size(); i++) {
-                        Infector<log_level, track_index_case>::Execute(
-                                m_primary_community[i], m_disease_profile, m_rng_handler[thread], m_calendar, log);
-                }
-                #pragma omp for schedule(runtime)
-                for (size_t i = 0; i < m_secondary_community.size(); i++) {
-                        Infector<log_level, track_index_case>::Execute(
-                                m_secondary_community[i], m_disease_profile, m_rng_handler[thread], m_calendar, log);
-                }
-        }
+#pragma omp for schedule(runtime)
+		for (size_t i = 0; i < m_households.size(); i++) {
+			Infector<log_level, track_index_case>::Execute(
+			    m_households[i], m_disease_profile, m_rng_handler[thread], m_calendar, log);
+		}
+#pragma omp for schedule(runtime)
+		for (size_t i = 0; i < m_school_clusters.size(); i++) {
+			Infector<log_level, track_index_case>::Execute(
+			    m_school_clusters[i], m_disease_profile, m_rng_handler[thread], m_calendar, log);
+		}
+#pragma omp for schedule(runtime)
+		for (size_t i = 0; i < m_work_clusters.size(); i++) {
+			Infector<log_level, track_index_case>::Execute(
+			    m_work_clusters[i], m_disease_profile, m_rng_handler[thread], m_calendar, log);
+		}
+#pragma omp for schedule(runtime)
+		for (size_t i = 0; i < m_primary_community.size(); i++) {
+			Infector<log_level, track_index_case>::Execute(
+			    m_primary_community[i], m_disease_profile, m_rng_handler[thread], m_calendar, log);
+		}
+#pragma omp for schedule(runtime)
+		for (size_t i = 0; i < m_secondary_community.size(); i++) {
+			Infector<log_level, track_index_case>::Execute(
+			    m_secondary_community[i], m_disease_profile, m_rng_handler[thread], m_calendar, log);
+		}
+	}
 }
 
 void Simulator::AddPersonToClusters(const Person& person)
 {
-        // Cluster id '0' means "not present in any cluster of that type".
-        auto hh_id = person.GetClusterId(ClusterType::Household);
-        if (hh_id > 0) {
-                m_households[hh_id].AddPerson(person);
-        }
-        auto sc_id = person.GetClusterId(ClusterType::School);
-        if (sc_id > 0) {
-                m_school_clusters[sc_id].AddPerson(person);
-        }
-        auto wo_id = person.GetClusterId(ClusterType::Work);
-        if (wo_id > 0) {
-                m_work_clusters[wo_id].AddPerson(person);
-        }
-        auto primCom_id = person.GetClusterId(ClusterType::PrimaryCommunity);
-        if (primCom_id > 0) {
-                m_primary_community[primCom_id].AddPerson(person);
-        }
-        auto secCom_id = person.GetClusterId(ClusterType::SecondaryCommunity);
-        if (secCom_id > 0) {
-                m_secondary_community[secCom_id].AddPerson(person);
-        }
+	// Cluster id '0' means "not present in any cluster of that type".
+	auto hh_id = person.GetClusterId(ClusterType::Household);
+	if (hh_id > 0) {
+		m_households[hh_id].AddPerson(person);
+	}
+	auto sc_id = person.GetClusterId(ClusterType::School);
+	if (sc_id > 0) {
+		m_school_clusters[sc_id].AddPerson(person);
+	}
+	auto wo_id = person.GetClusterId(ClusterType::Work);
+	if (wo_id > 0) {
+		m_work_clusters[wo_id].AddPerson(person);
+	}
+	auto primCom_id = person.GetClusterId(ClusterType::PrimaryCommunity);
+	if (primCom_id > 0) {
+		m_primary_community[primCom_id].AddPerson(person);
+	}
+	auto secCom_id = person.GetClusterId(ClusterType::SecondaryCommunity);
+	if (secCom_id > 0) {
+		m_secondary_community[secCom_id].AddPerson(person);
+	}
 }
 
 void Simulator::RemovePersonFromClusters(const Person& person)
 {
-        // Cluster id '0' means "not present in any cluster of that type".
-        auto hh_id = person.GetClusterId(ClusterType::Household);
-        if (hh_id > 0) {
-                m_households[hh_id].RemovePerson(person);
-        }
-        auto sc_id = person.GetClusterId(ClusterType::School);
-        if (sc_id > 0) {
-                m_school_clusters[sc_id].RemovePerson(person);
-        }
-        auto wo_id = person.GetClusterId(ClusterType::Work);
-        if (wo_id > 0) {
-                m_work_clusters[wo_id].RemovePerson(person);
-        }
-        auto primCom_id = person.GetClusterId(ClusterType::PrimaryCommunity);
-        if (primCom_id > 0) {
-                m_primary_community[primCom_id].RemovePerson(person);
-        }
-        auto secCom_id = person.GetClusterId(ClusterType::SecondaryCommunity);
-        if (secCom_id > 0) {
-                m_secondary_community[secCom_id].RemovePerson(person);
-        }
+	// Cluster id '0' means "not present in any cluster of that type".
+	auto hh_id = person.GetClusterId(ClusterType::Household);
+	if (hh_id > 0) {
+		m_households[hh_id].RemovePerson(person);
+	}
+	auto sc_id = person.GetClusterId(ClusterType::School);
+	if (sc_id > 0) {
+		m_school_clusters[sc_id].RemovePerson(person);
+	}
+	auto wo_id = person.GetClusterId(ClusterType::Work);
+	if (wo_id > 0) {
+		m_work_clusters[wo_id].RemovePerson(person);
+	}
+	auto primCom_id = person.GetClusterId(ClusterType::PrimaryCommunity);
+	if (primCom_id > 0) {
+		m_primary_community[primCom_id].RemovePerson(person);
+	}
+	auto secCom_id = person.GetClusterId(ClusterType::SecondaryCommunity);
+	if (secCom_id > 0) {
+		m_secondary_community[secCom_id].RemovePerson(person);
+	}
 }
 
 PersonId Simulator::GeneratePersonId()
 {
-        // TODO: recycle ids
-        return m_population->get_max_id() + 1;
+	// TODO: recycle ids
+	return m_population->get_max_id() + 1;
 }
 
 std::size_t Simulator::GenerateHousehold()
 {
-        // TODO: recycle households
-        auto household_id = m_households.size();
-        m_households.emplace_back(household_id, ClusterType::Household);
-        return household_id;
+	// TODO: recycle households
+	auto household_id = m_households.size();
+	m_households.emplace_back(household_id, ClusterType::Household);
+	return household_id;
 }
 
 void Simulator::RecyclePersonId(PersonId id)
 {
-        // TODO: recycle ids
+	// TODO: recycle ids
 }
 
 void Simulator::RecycleHousehold(std::size_t household_id)
 {
-        // TODO: recycle households
+	// TODO: recycle households
 }
 
 void Simulator::AcceptVisitors(const multiregion::SimulationStepInput& input)
 {
-        for (const auto& returning_expat : input.expatriates) {
-                // Return the expatriate to this region's population.
-                auto returned_expat = *m_population->emplace(returning_expat);
+	for (const auto& returning_expat : input.expatriates) {
+		// Return the expatriate to this region's population.
+		auto returned_expat = *m_population->emplace(returning_expat);
 
-                auto home_expat = m_expatriates.extract_expatriate(returning_expat.GetId());
+		auto home_expat = m_expatriates.extract_expatriate(returning_expat.GetId());
 
-                // Update the returning expatriate's clusters.
-                for (std::size_t i = 0; i < NumOfClusterTypes(); i++) {
-                        auto cluster_type = static_cast<ClusterType>(i);
-                        returned_expat.GetClusterId(cluster_type) = home_expat.GetClusterId(cluster_type);
-                }
+		// Update the returning expatriate's clusters.
+		for (std::size_t i = 0; i < NumOfClusterTypes(); i++) {
+			auto cluster_type = static_cast<ClusterType>(i);
+			returned_expat.GetClusterId(cluster_type) = home_expat.GetClusterId(cluster_type);
+		}
 
-                // Add the returning expatriate to their clusters.
-                AddPersonToClusters(returned_expat);
-        }
+		// Add the returning expatriate to their clusters.
+		AddPersonToClusters(returned_expat);
+	}
 
-        for (const auto& visitor : input.visitors) {
-                // Generate local ids and create a household cluster for the visitor.
-                auto id = GeneratePersonId();
-                auto household_id = GenerateHousehold();
-                auto work_id = (*m_travel_rng)(m_work_clusters.size() - 1);
-                auto primary_community_id = (*m_travel_rng)(m_primary_community.size() - 1);
-                auto secondary_community_id = (*m_travel_rng)(m_secondary_community.size() - 1);
+	for (const auto& visitor : input.visitors) {
+		// Generate local ids and create a household cluster for the visitor.
+		auto id = GeneratePersonId();
+		auto household_id = GenerateHousehold();
+		auto work_id = (*m_travel_rng)(m_work_clusters.size() - 1);
+		auto primary_community_id = (*m_travel_rng)(m_primary_community.size() - 1);
+		auto secondary_community_id = (*m_travel_rng)(m_secondary_community.size() - 1);
 
-                // Insert the visitor in the population.
-                Person local_visitor = *m_population->emplace(
-                        id, visitor.person.GetAge(), household_id, 0, work_id,
-                        primary_community_id, secondary_community_id, disease::Fate());
+		// Insert the visitor in the population.
+		Person local_visitor = *m_population->emplace(
+		    id, visitor.person.GetAge(), household_id, 0, work_id, primary_community_id, secondary_community_id,
+		    disease::Fate());
 
-                // Set the visitor's health.
-                local_visitor.GetHealth() = visitor.person.GetHealth();
+		// Set the visitor's health.
+		local_visitor.GetHealth() = visitor.person.GetHealth();
 
-                // Add the visitor to their assigned clusters.
-                AddPersonToClusters(local_visitor);
+		// Add the visitor to their assigned clusters.
+		AddPersonToClusters(local_visitor);
 
-                // Add an entry to the visitor log.
-                multiregion::VisitorId visitor_desc;
-                visitor_desc.home_id = visitor.person.GetId();
-                visitor_desc.visitor_id = id;
-                m_visitors.add_visitor(visitor_desc, visitor.home_region, visitor.return_day);
-        }
+		// Add an entry to the visitor log.
+		multiregion::VisitorId visitor_desc;
+		visitor_desc.home_id = visitor.person.GetId();
+		visitor_desc.visitor_id = id;
+		m_visitors.add_visitor(visitor_desc, visitor.home_region, visitor.return_day);
+	}
 }
 
 multiregion::SimulationStepOutput Simulator::ReturnVisitors()
 {
-        // First, find visitors which we can return.
-        std::vector<multiregion::OutgoingVisitor> returning_expatriates;
-        auto today = m_calendar->GetSimulationDay();
-        for (const auto& expatriate_pair : m_visitors.extract_visitors(today)) {
-                for (const auto& expatriate : expatriate_pair.second) {
-                        auto person = m_population->extract(expatriate.visitor_id);
+	// First, find visitors which we can return.
+	std::vector<multiregion::OutgoingVisitor> returning_expatriates;
+	auto today = m_calendar->GetSimulationDay();
+	for (const auto& expatriate_pair : m_visitors.extract_visitors(today)) {
+		for (const auto& expatriate : expatriate_pair.second) {
+			auto person = m_population->extract(expatriate.visitor_id);
 
-                        // Recycle the person's id and their household.
-                        RecyclePersonId(person.GetId());
-                        RecycleHousehold(person.GetClusterId(ClusterType::Household));
+			// Recycle the person's id and their household.
+			RecyclePersonId(person.GetId());
+			RecycleHousehold(person.GetClusterId(ClusterType::Household));
 
-                        // Restore the person's id to their home id.
-                        returning_expatriates.emplace_back(person.WithId(expatriate.home_id), expatriate_pair.first, today);
-                }
-        }
+			// Restore the person's id to their home id.
+			returning_expatriates.emplace_back(
+			    person.WithId(expatriate.home_id), expatriate_pair.first, today);
+		}
+	}
 
-        // Next, create a list of people which we'd like to send elsewhere.
-        std::vector<multiregion::OutgoingVisitor> outgoing_visitors;
-        auto travel_model = m_config.travel_model;
+	// Next, create a list of people which we'd like to send elsewhere.
+	std::vector<multiregion::OutgoingVisitor> outgoing_visitors;
+	auto travel_model = m_config.travel_model;
 
-        // Build a model of where we want to send people.
-        std::unordered_map<multiregion::RegionId, double> probabilities;
-        for (const auto& airport : travel_model->GetLocalAirports()) {
-                double route_probability_sum = 0.0;
-                for (const auto& route : airport->routes) {
-                        route_probability_sum += route.passenger_fraction;
-                }
-                for (const auto& route : airport->routes) {
-                        probabilities[route.target->region_id] += route.passenger_fraction *
-                                airport->passenger_fraction / route_probability_sum;
-                }
-        }
+	// Build a model of where we want to send people.
+	std::unordered_map<multiregion::RegionId, double> probabilities;
+	for (const auto& airport : travel_model->GetLocalAirports()) {
+		double route_probability_sum = 0.0;
+		for (const auto& route : airport->routes) {
+			route_probability_sum += route.passenger_fraction;
+		}
+		for (const auto& route : airport->routes) {
+			probabilities[route.target->region_id] +=
+			    route.passenger_fraction * airport->passenger_fraction / route_probability_sum;
+		}
+	}
 
-        if (probabilities.size() == 0) {
-                // Looks like we won't be sending people anywhere anytime soon.
-                return {std::move(outgoing_visitors), std::move(returning_expatriates)};
-        }
+	if (probabilities.size() == 0) {
+		// Looks like we won't be sending people anywhere anytime soon.
+		return {std::move(outgoing_visitors), std::move(returning_expatriates)};
+	}
 
-        auto target_region_generator = alias::BiasedRandomValueGenerator<multiregion::RegionId>::CreateDistribution(
-                probabilities, *m_travel_rng);
+	auto target_region_generator =
+	    alias::BiasedRandomValueGenerator<multiregion::RegionId>::CreateDistribution(probabilities, *m_travel_rng);
 
-        // Gather the people we're going to ship off to another region.
-        auto number_of_visitors = static_cast<std::size_t>(std::max(0.0, std::floor(
-                static_cast<double>(m_population->size() - m_visitors.get_visitor_count()) * travel_model->GetTravelFraction())));
+	// Gather the people we're going to ship off to another region.
+	auto number_of_visitors = static_cast<std::size_t>(std::max(
+	    0.0, std::floor(
+		     static_cast<double>(m_population->size() - m_visitors.get_visitor_count()) *
+		     travel_model->GetTravelFraction())));
 
-        for (auto visitor : m_population->get_random_persons(
-                *m_travel_rng, number_of_visitors,
-                [this](const Person& p) -> bool { return !m_visitors.is_visitor(p.GetId()); })) {
-                // Pick a region to which we'll send this person.
-                auto target_region_id = target_region_generator.Next();
+	for (auto visitor :
+	     m_population->get_random_persons(*m_travel_rng, number_of_visitors, [this](const Person& p) -> bool {
+		     return !m_visitors.is_visitor(p.GetId());
+	     })) {
+		// Pick a region to which we'll send this person.
+		auto target_region_id = target_region_generator.Next();
 
-                // Remove the person from their clusters.
-                RemovePersonFromClusters(visitor);
+		// Remove the person from their clusters.
+		RemovePersonFromClusters(visitor);
 
-                auto return_date = today + (*m_travel_rng)(
-                        (int)travel_model->GetMinTravelDuration(), (int)travel_model->GetMaxTravelDuration());
+		auto return_date =
+		    today + (*m_travel_rng)(
+				(int)travel_model->GetMinTravelDuration(), (int)travel_model->GetMaxTravelDuration());
 
-                outgoing_visitors.emplace_back(visitor, target_region_id, return_date);
+		outgoing_visitors.emplace_back(visitor, target_region_id, return_date);
 
-                // Remove the person from the population and add them to the expatriate journal.
-                m_expatriates.add_expatriate(m_population->extract(visitor.GetId()));
-        }
+		// Remove the person from the population and add them to the expatriate journal.
+		m_expatriates.add_expatriate(m_population->extract(visitor.GetId()));
+	}
 
-        return {std::move(outgoing_visitors), std::move(returning_expatriates)};
+	return {std::move(outgoing_visitors), std::move(returning_expatriates)};
 }
 
 multiregion::SimulationStepOutput Simulator::TimeStep(const multiregion::SimulationStepInput& input)
 {
-        AcceptVisitors(input);
-        shared_ptr<DaysOffInterface> days_off {nullptr};
+	AcceptVisitors(input);
+	shared_ptr<DaysOffInterface> days_off{nullptr};
 
-        // Logic where you compute (on the basis of input/config for initial day
-        // or on the basis of number of sick persons, duration of epidemic etc)
-        // what kind of DaysOff scheme you apply. If we want to make this cluster
-        // dependent then the days_off object has to be passed into the Update function.
-        days_off = make_shared<DaysOffStandard>(m_calendar);
-        const bool is_work_off {days_off->IsWorkOff() };
-        const bool is_school_off { days_off->IsSchoolOff() };
+	// Logic where you compute (on the basis of input/config for initial day
+	// or on the basis of number of sick persons, duration of epidemic etc)
+	// what kind of DaysOff scheme you apply. If we want to make this cluster
+	// dependent then the days_off object has to be passed into the Update function.
+	days_off = make_shared<DaysOffStandard>(m_calendar);
+	const bool is_work_off{days_off->IsWorkOff()};
+	const bool is_school_off{days_off->IsSchoolOff()};
 
-        for (const auto& p : *m_population) {
-                p.Update(is_work_off, is_school_off);
-        }
+	for (const auto& p : *m_population) {
+		p.Update(is_work_off, is_school_off);
+	}
 
-        if (m_track_index_case) {
-                switch (m_log_level) {
-                        case LogMode::Contacts:
-                                UpdateClusters<LogMode::Contacts, true>(); break;
-                        case LogMode::Transmissions:
-                                UpdateClusters<LogMode::Transmissions, true>(); break;
-                        case LogMode::None:
-                                UpdateClusters<LogMode::None, true>(); break;
-                        default:
-                                throw runtime_error(std::string(__func__) + "Log mode screwed up!");
-                }
-        } else {
-                switch (m_log_level) {
-                        case LogMode::Contacts:
-                                UpdateClusters<LogMode::Contacts, false>(); break;
-                        case LogMode::Transmissions:
-                                UpdateClusters<LogMode::Transmissions, false>();  break;
-                        case LogMode::None:
-                                UpdateClusters<LogMode::None, false>(); break;
-                        default:
-                                throw runtime_error(std::string(__func__) + "Log mode screwed up!");
-                }
-        }
+	if (m_track_index_case) {
+		switch (m_log_level) {
+		case LogMode::Contacts:
+			UpdateClusters<LogMode::Contacts, true>();
+			break;
+		case LogMode::Transmissions:
+			UpdateClusters<LogMode::Transmissions, true>();
+			break;
+		case LogMode::None:
+			UpdateClusters<LogMode::None, true>();
+			break;
+		default:
+			throw runtime_error(std::string(__func__) + "Log mode screwed up!");
+		}
+	} else {
+		switch (m_log_level) {
+		case LogMode::Contacts:
+			UpdateClusters<LogMode::Contacts, false>();
+			break;
+		case LogMode::Transmissions:
+			UpdateClusters<LogMode::Transmissions, false>();
+			break;
+		case LogMode::None:
+			UpdateClusters<LogMode::None, false>();
+			break;
+		default:
+			throw runtime_error(std::string(__func__) + "Log mode screwed up!");
+		}
+	}
 
-        m_calendar->AdvanceDay();
-        return ReturnVisitors();
+	m_calendar->AdvanceDay();
+	return ReturnVisitors();
 }
 } // end_of_namespace

--- a/src/main/cpp/sim/Simulator.cpp
+++ b/src/main/cpp/sim/Simulator.cpp
@@ -48,10 +48,6 @@ Simulator::Simulator()
 {
 }
 
-const shared_ptr<const Population> Simulator::GetPopulation() const { return m_population; }
-
-SingleSimulationConfig Simulator::GetConfiguration() const { return m_config; }
-
 void Simulator::SetTrackIndexCase(bool track_index_case) { m_track_index_case = track_index_case; }
 
 template <LogMode log_level, bool track_index_case>

--- a/src/main/cpp/sim/Simulator.cpp
+++ b/src/main/cpp/sim/Simulator.cpp
@@ -162,12 +162,6 @@ void Simulator::AcceptVisitors(const multiregion::SimulationStepInput& input)
                 // Set the visitor's health.
                 local_visitor.GetHealth() = visitor.person.GetHealth();
 
-                // Clear the visitor's clusters.
-                for (std::size_t i = 0; i < NumOfClusterTypes(); i++) {
-                        auto cluster_type = static_cast<ClusterType>(i);
-                        local_visitor.GetClusterId(cluster_type) = 0;
-                }
-
                 // Add the visitor to their assigned clusters.
                 AddPersonToClusters(local_visitor);
 

--- a/src/main/cpp/sim/Simulator.cpp
+++ b/src/main/cpp/sim/Simulator.cpp
@@ -262,8 +262,8 @@ multiregion::SimulationStepOutput Simulator::ReturnVisitors()
                 probabilities, *m_travel_rng);
 
         // Gather the people we're going to ship off to another region.
-        auto number_of_visitors = static_cast<std::size_t>(
-                static_cast<double>(m_population->size()) * travel_model->GetTravelFraction());
+        auto number_of_visitors = static_cast<std::size_t>(std::max(0.0, std::floor(
+                static_cast<double>(m_population->size() - m_visitors.get_visitor_count()) * travel_model->GetTravelFraction())));
 
         for (auto visitor : m_population->get_random_persons(
                 *m_travel_rng, number_of_visitors,

--- a/src/main/cpp/sim/Simulator.cpp
+++ b/src/main/cpp/sim/Simulator.cpp
@@ -27,6 +27,7 @@
 #include "core/Infector.h"
 #include "core/LogMode.h"
 #include "pop/Population.h"
+#include "multiregion/Visitor.h"
 
 #include <spdlog/spdlog.h>
 #include <boost/property_tree/ptree.hpp>
@@ -97,7 +98,7 @@ void Simulator::UpdateClusters()
         }
 }
 
-void Simulator::TimeStep()
+multiregion::SimulationStepOutput Simulator::TimeStep(const multiregion::SimulationStepInput& input)
 {
         shared_ptr<DaysOffInterface> days_off {nullptr};
 
@@ -138,5 +139,6 @@ void Simulator::TimeStep()
         }
 
         m_calendar->AdvanceDay();
+        return multiregion::SimulationStepOutput();
 }
 } // end_of_namespace

--- a/src/main/cpp/sim/Simulator.cpp
+++ b/src/main/cpp/sim/Simulator.cpp
@@ -10,7 +10,8 @@
  *  You should have received a copy of the GNU General Public License
  *  along with the software. If not, see <http://www.gnu.org/licenses/>.
  *
- *  Copyright 2015, Willem L, Kuylen E, Stijven S & Broeckhove J
+ *  Copyright 2017, Willem L, Kuylen E, Stijven S, Broeckhove J
+ *  Aerts S, De Haes C, Van der Cruysse J & Van Hauwe L
  */
 
 /**

--- a/src/main/cpp/sim/Simulator.cpp
+++ b/src/main/cpp/sim/Simulator.cpp
@@ -98,6 +98,31 @@ void Simulator::UpdateClusters()
         }
 }
 
+void Simulator::AddPersonToClusters(Person& person)
+{
+        // Cluster id '0' means "not present in any cluster of that type".
+        auto hh_id = person.GetClusterId(ClusterType::Household);
+        if (hh_id > 0) {
+                m_households[hh_id].AddPerson(&person);
+        }
+        auto sc_id = person.GetClusterId(ClusterType::School);
+        if (sc_id > 0) {
+                m_school_clusters[sc_id].AddPerson(&person);
+        }
+        auto wo_id = person.GetClusterId(ClusterType::Work);
+        if (wo_id > 0) {
+                m_work_clusters[wo_id].AddPerson(&person);
+        }
+        auto primCom_id = person.GetClusterId(ClusterType::PrimaryCommunity);
+        if (primCom_id > 0) {
+                m_primary_community[primCom_id].AddPerson(&person);
+        }
+        auto secCom_id = person.GetClusterId(ClusterType::SecondaryCommunity);
+        if (secCom_id > 0) {
+                m_secondary_community[secCom_id].AddPerson(&person);
+        }
+}
+
 void Simulator::AcceptVisitors(const multiregion::SimulationStepInput& input)
 {
 

--- a/src/main/cpp/sim/Simulator.cpp
+++ b/src/main/cpp/sim/Simulator.cpp
@@ -232,8 +232,7 @@ multiregion::SimulationStepOutput Simulator::ReturnVisitors()
                         RecycleHousehold(person.GetClusterId(ClusterType::Household));
 
                         // Restore the person's id to their home id.
-                        person.GetId() = expatriate.home_id;
-                        returning_expatriates.emplace_back(person, expatriate_pair.first, today);
+                        returning_expatriates.emplace_back(person.WithId(expatriate.home_id), expatriate_pair.first, today);
                 }
         }
 

--- a/src/main/cpp/sim/Simulator.h
+++ b/src/main/cpp/sim/Simulator.h
@@ -49,10 +49,10 @@ public:
 	Simulator();
 
 	/// Get the population.
-	const PopulationRef GetPopulation() const;
+	PopulationRef GetPopulation() const { return m_population; }
 
 	/// Gets the simulator's configuration.
-	SingleSimulationConfig GetConfiguration() const;
+	SingleSimulationConfig GetConfiguration() const { return m_config; }
 
 	/// Change track_index_case setting.
 	void SetTrackIndexCase(bool track_index_case);

--- a/src/main/cpp/sim/Simulator.h
+++ b/src/main/cpp/sim/Simulator.h
@@ -71,6 +71,9 @@ private:
 	/// home regions.
 	multiregion::SimulationStepOutput ReturnVisitors();
 
+	/// Adds the given person to the clusters they've been assigned to.
+	void AddPersonToClusters(Person& person);
+
         /// Update the contacts in the given clusters.
 	template<LogMode log_level, bool track_index_case = false>
         void UpdateClusters();

--- a/src/main/cpp/sim/Simulator.h
+++ b/src/main/cpp/sim/Simulator.h
@@ -74,6 +74,9 @@ private:
 	/// Adds the given person to the clusters they've been assigned to.
 	void AddPersonToClusters(Person& person);
 
+	/// Removes the given person from the clusters they've been assigned to.
+	void RemovePersonFromClusters(Person& person);
+
 	/// Generates an id for a person that is not in use.
 	PersonId GeneratePersonId();
 

--- a/src/main/cpp/sim/Simulator.h
+++ b/src/main/cpp/sim/Simulator.h
@@ -72,10 +72,10 @@ private:
 	multiregion::SimulationStepOutput ReturnVisitors();
 
 	/// Adds the given person to the clusters they've been assigned to.
-	void AddPersonToClusters(Person& person);
+	void AddPersonToClusters(const Person& person);
 
 	/// Removes the given person from the clusters they've been assigned to.
-	void RemovePersonFromClusters(Person& person);
+	void RemovePersonFromClusters(const Person& person);
 
 	/// Generates an id for a person that is not in use.
 	PersonId GeneratePersonId();

--- a/src/main/cpp/sim/Simulator.h
+++ b/src/main/cpp/sim/Simulator.h
@@ -77,6 +77,15 @@ private:
 	/// Generates an id for a person that is not in use.
 	PersonId GeneratePersonId();
 
+	/// Generates a new household cluster and returns its id.
+	std::size_t GenerateHousehold();
+
+	/// Recycles the given person id.
+	void RecyclePersonId(PersonId id);
+
+	/// Recycles the household with the given id.
+	void RecycleHousehold(std::size_t household_id);
+
         /// Update the contacts in the given clusters.
 	template<LogMode log_level, bool track_index_case = false>
         void UpdateClusters();

--- a/src/main/cpp/sim/Simulator.h
+++ b/src/main/cpp/sim/Simulator.h
@@ -74,6 +74,9 @@ private:
 	/// Adds the given person to the clusters they've been assigned to.
 	void AddPersonToClusters(Person& person);
 
+	/// Generates an id for a person that is not in use.
+	PersonId GeneratePersonId();
+
         /// Update the contacts in the given clusters.
 	template<LogMode log_level, bool track_index_case = false>
         void UpdateClusters();
@@ -85,6 +88,7 @@ private:
 private:
 	unsigned int                        m_num_threads;          ///< The number of (OpenMP) threads.
     std::vector<RngHandler>             m_rng_handler;          ///< Pointer to the RngHandlers.
+    std::shared_ptr<util::Random>       m_travel_rng;           ///< A random number generator for travel.
     LogMode                             m_log_level;            ///< Specifies logging mode.
     std::shared_ptr<Calendar>           m_calendar;             ///< Management of calendar.
 

--- a/src/main/cpp/sim/Simulator.h
+++ b/src/main/cpp/sim/Simulator.h
@@ -12,7 +12,8 @@
  *  You should have received a copy of the GNU General Public License
  *  along with the software. If not, see <http://www.gnu.org/licenses/>.
  *
- *  Copyright 2017, Willem L, Kuylen E, Stijven S & Broeckhove J
+ *  Copyright 2017, Willem L, Kuylen E, Stijven S, Broeckhove J
+ *  Aerts S, De Haes C, Van der Cruysse J & Van Hauwe L
  */
 
 /**

--- a/src/main/cpp/sim/Simulator.h
+++ b/src/main/cpp/sim/Simulator.h
@@ -59,6 +59,9 @@ public:
         /// Run one time step, computing full simulation (default) or only index case.
         void TimeStep();
 
+        /// Tests if this simulation has run to completion.
+        bool IsDone() const { return m_calendar->GetSimulationDay() >= m_config.common_config->number_of_days; }
+
 private:
         /// Update the contacts in the given clusters.
 	template<LogMode log_level, bool track_index_case = false>

--- a/src/main/cpp/sim/Simulator.h
+++ b/src/main/cpp/sim/Simulator.h
@@ -24,6 +24,7 @@
 #include "core/DiseaseProfile.h"
 #include "core/LogMode.h"
 #include "core/RngHandler.h"
+#include "multiregion/Visitor.h"
 #include "multiregion/VisitorJournal.h"
 #include "sim/SimulationConfig.h"
 
@@ -57,7 +58,7 @@ public:
         void SetTrackIndexCase(bool track_index_case);
 
         /// Run one time step, computing full simulation (default) or only index case.
-        void TimeStep();
+        multiregion::SimulationStepOutput TimeStep(const multiregion::SimulationStepInput& input);
 
         /// Tests if this simulation has run to completion.
         bool IsDone() const { return m_calendar->GetSimulationDay() >= m_config.common_config->number_of_days; }

--- a/src/main/cpp/sim/Simulator.h
+++ b/src/main/cpp/sim/Simulator.h
@@ -64,6 +64,13 @@ public:
         bool IsDone() const { return m_calendar->GetSimulationDay() >= m_config.common_config->number_of_days; }
 
 private:
+	/// Accepts visitors from other regions.
+	void AcceptVisitors(const multiregion::SimulationStepInput& input);
+
+	/// Returns visitors whose return trip is scheduled today and returns them to their
+	/// home regions.
+	multiregion::SimulationStepOutput ReturnVisitors();
+
         /// Update the contacts in the given clusters.
 	template<LogMode log_level, bool track_index_case = false>
         void UpdateClusters();

--- a/src/main/cpp/sim/Simulator.h
+++ b/src/main/cpp/sim/Simulator.h
@@ -26,17 +26,16 @@
 #include "core/RngHandler.h"
 #include "multiregion/Visitor.h"
 #include "multiregion/VisitorJournal.h"
+#include "pop/Population.h"
 #include "sim/SimulationConfig.h"
 
-#include <spdlog/spdlog.h>
-#include <boost/property_tree/ptree.hpp>
 #include <memory>
-#include <string>
 #include <vector>
+#include <boost/property_tree/ptree.hpp>
+#include <spdlog/spdlog.h>
 
 namespace stride {
 
-class Population;
 class Calendar;
 
 /**
@@ -45,23 +44,23 @@ class Calendar;
 class Simulator
 {
 public:
-        // Default constructor for empty Simulator.
-        Simulator();
+	// Default constructor for empty Simulator.
+	Simulator();
 
-        /// Get the population.
-        const std::shared_ptr<const Population> GetPopulation() const;
+	/// Get the population.
+	const PopulationRef GetPopulation() const;
 
-        /// Gets the simulator's configuration.
-        SingleSimulationConfig GetConfiguration() const;
+	/// Gets the simulator's configuration.
+	SingleSimulationConfig GetConfiguration() const;
 
-        /// Change track_index_case setting.
-        void SetTrackIndexCase(bool track_index_case);
+	/// Change track_index_case setting.
+	void SetTrackIndexCase(bool track_index_case);
 
-        /// Run one time step, computing full simulation (default) or only index case.
-        multiregion::SimulationStepOutput TimeStep(const multiregion::SimulationStepInput& input);
+	/// Run one time step, computing full simulation (default) or only index case.
+	multiregion::SimulationStepOutput TimeStep(const multiregion::SimulationStepInput& input);
 
-        /// Tests if this simulation has run to completion.
-        bool IsDone() const { return m_calendar->GetSimulationDay() >= m_config.common_config->number_of_days; }
+	/// Tests if this simulation has run to completion.
+	bool IsDone() const { return m_calendar->GetSimulationDay() >= m_config.common_config->number_of_days; }
 
 private:
 	/// Accepts visitors from other regions.
@@ -89,35 +88,35 @@ private:
 	/// Recycles the household with the given id.
 	void RecycleHousehold(std::size_t household_id);
 
-        /// Update the contacts in the given clusters.
-	template<LogMode log_level, bool track_index_case = false>
-        void UpdateClusters();
+	/// Update the contacts in the given clusters.
+	template <LogMode log_level, bool track_index_case = false>
+	void UpdateClusters();
 
 private:
-	SingleSimulationConfig              m_config;               ///< Configuration for this simulator.
-	std::shared_ptr<spdlog::logger>     m_log;                  ///< Log for this simulator.
+	SingleSimulationConfig m_config;       ///< Configuration for this simulator.
+	std::shared_ptr<spdlog::logger> m_log; ///< Log for this simulator.
 
 private:
-	unsigned int                        m_num_threads;          ///< The number of (OpenMP) threads.
-    std::vector<RngHandler>             m_rng_handler;          ///< Pointer to the RngHandlers.
-    std::shared_ptr<util::Random>       m_travel_rng;           ///< A random number generator for travel.
-    LogMode                             m_log_level;            ///< Specifies logging mode.
-    std::shared_ptr<Calendar>           m_calendar;             ///< Management of calendar.
+	unsigned int m_num_threads;		    ///< The number of (OpenMP) threads.
+	std::vector<RngHandler> m_rng_handler;      ///< Pointer to the RngHandlers.
+	std::shared_ptr<util::Random> m_travel_rng; ///< A random number generator for travel.
+	LogMode m_log_level;			    ///< Specifies logging mode.
+	std::shared_ptr<Calendar> m_calendar;       ///< Management of calendar.
 
 private:
-    std::shared_ptr<Population>         m_population;           ///< Pointer to the Population.
-    stride::multiregion::VisitorJournal m_visitors;             ///< Visitor journal.
-    stride::multiregion::ExpatriateJournal m_expatriates;       ///< Expatriate journal.
+	std::shared_ptr<Population> m_population;	     ///< Pointer to the Population.
+	stride::multiregion::VisitorJournal m_visitors;       ///< Visitor journal.
+	stride::multiregion::ExpatriateJournal m_expatriates; ///< Expatriate journal.
 
-	std::vector<Cluster>                m_households;           ///< Container with household Clusters.
-    std::vector<Cluster>                m_school_clusters;      ///< Container with school Clusters.
-    std::vector<Cluster>                m_work_clusters;        ///< Container with work Clusters.
-	std::vector<Cluster>                m_primary_community;    ///< Container with primary community Clusters.
-	std::vector<Cluster>                m_secondary_community;  ///< Container with secondary community  Clusters.
+	std::vector<Cluster> m_households;	  ///< Container with household Clusters.
+	std::vector<Cluster> m_school_clusters;     ///< Container with school Clusters.
+	std::vector<Cluster> m_work_clusters;       ///< Container with work Clusters.
+	std::vector<Cluster> m_primary_community;   ///< Container with primary community Clusters.
+	std::vector<Cluster> m_secondary_community; ///< Container with secondary community  Clusters.
 
-	DiseaseProfile                      m_disease_profile;      ///< Profile of disease.
+	DiseaseProfile m_disease_profile; ///< Profile of disease.
 
-	bool                                m_track_index_case;     ///< General simulation or tracking index case.
+	bool m_track_index_case; ///< General simulation or tracking index case.
 
 private:
 	friend class SimulatorBuilder;

--- a/src/main/cpp/sim/Simulator.h
+++ b/src/main/cpp/sim/Simulator.h
@@ -24,6 +24,7 @@
 #include "core/DiseaseProfile.h"
 #include "core/LogMode.h"
 #include "core/RngHandler.h"
+#include "multiregion/VisitorJournal.h"
 #include "sim/SimulationConfig.h"
 
 #include <spdlog/spdlog.h>
@@ -75,6 +76,8 @@ private:
 
 private:
     std::shared_ptr<Population>         m_population;           ///< Pointer to the Population.
+    stride::multiregion::VisitorJournal m_visitors;             ///< Visitor journal.
+    stride::multiregion::ExpatriateJournal m_expatriates;       ///< Expatriate journal.
 
 	std::vector<Cluster>                m_households;           ///< Container with household Clusters.
     std::vector<Cluster>                m_school_clusters;      ///< Container with school Clusters.

--- a/src/main/cpp/sim/SimulatorBuilder.cpp
+++ b/src/main/cpp/sim/SimulatorBuilder.cpp
@@ -206,28 +206,8 @@ void SimulatorBuilder::InitializeClusters(shared_ptr<Simulator> sim)
 		cluster_id++;
 	}
 
-	// Cluster id '0' means "not present in any cluster of that type".
 	for (auto& p: population) {
-	        const auto hh_id = p.GetClusterId(ClusterType::Household);
-		if (hh_id > 0) {
-		        sim->m_households[hh_id].AddPerson(&p);
-		}
-		const auto sc_id = p.GetClusterId(ClusterType::School);
-		if (sc_id > 0) {
-				sim->m_school_clusters[sc_id].AddPerson(&p);
-		}
-		const auto wo_id = p.GetClusterId(ClusterType::Work);
-		if (wo_id > 0) {
-				sim->m_work_clusters[wo_id].AddPerson(&p);
-		}
-		const auto primCom_id = p.GetClusterId(ClusterType::PrimaryCommunity);
-		if (primCom_id > 0) {
-		        sim->m_primary_community[primCom_id].AddPerson(&p);
-		}
-		const auto secCom_id = p.GetClusterId(ClusterType::SecondaryCommunity);
-		if (secCom_id > 0) {
-		        sim->m_secondary_community[secCom_id].AddPerson(&p);
-		}
+		sim->AddPersonToClusters(p);
 	}
 }
 

--- a/src/main/cpp/sim/SimulatorBuilder.cpp
+++ b/src/main/cpp/sim/SimulatorBuilder.cpp
@@ -134,11 +134,12 @@ shared_ptr<Simulator> SimulatorBuilder::Build(
         // Get log level.
         sim->m_log_level = config.log_config->log_level;
 
-        // Rng's.
-        Random rng(config.common_config->rng_seed);
+        // Create a random number generator for the simulator.
+        auto rng = std::make_shared<Random>(config.common_config->rng_seed);
 
         // Build population.
-        sim->m_population = PopulationBuilder::Build(config, pt_disease, rng, log);
+        sim->m_travel_rng = rng;
+        sim->m_population = PopulationBuilder::Build(config, pt_disease, *rng, log);
 
         // Initialize clusters.
         InitializeClusters(sim);
@@ -147,7 +148,7 @@ shared_ptr<Simulator> SimulatorBuilder::Build(
         sim->m_disease_profile.Initialize(config, pt_disease);
 
         // Initialize Rng handlers
-        unsigned int new_seed = rng(numeric_limits<unsigned int>::max());
+        unsigned int new_seed = (*rng)(numeric_limits<unsigned int>::max());
         for (size_t i = 0; i < sim->m_num_threads; i++) {
                 sim->m_rng_handler.emplace_back(RngHandler(new_seed, sim->m_num_threads, i));
         }

--- a/src/main/cpp/sim/SimulatorBuilder.cpp
+++ b/src/main/cpp/sim/SimulatorBuilder.cpp
@@ -207,7 +207,7 @@ void SimulatorBuilder::InitializeClusters(shared_ptr<Simulator> sim)
 		cluster_id++;
 	}
 
-	for (auto& p: population) {
+	for (const auto& p : population) {
 		sim->AddPersonToClusters(p);
 	}
 }

--- a/src/main/cpp/sim/run_stride.cpp
+++ b/src/main/cpp/sim/run_stride.cpp
@@ -21,7 +21,7 @@
 
 #include "run_stride.h"
 
-#include "multiregion/SequentialSimulationManager.h"
+#include "multiregion/ParallelSimulationManager.h"
 #include "multiregion/SimulationManager.h"
 #include "multiregion/TravelModel.h"
 #include "output/CasesFile.h"
@@ -152,7 +152,8 @@ void run_stride(const MultiSimulationConfig& config)
 	// Create simulator.
 	// -----------------------------------------------------------------------------------------
 	Stopwatch<> total_clock("total_clock", true);
-	multiregion::SequentialSimulationManager<StrideSimulatorResult, multiregion::RegionId> sim_manager{num_threads};
+	multiregion::ParallelSimulationManager<StrideSimulatorResult, multiregion::RegionId> sim_manager{
+	    config.region_models.size(), num_threads};
 
 	// Build all the simulations.
 	struct SimulationTuple

--- a/src/main/cpp/sim/run_stride.cpp
+++ b/src/main/cpp/sim/run_stride.cpp
@@ -21,7 +21,7 @@
 
 #include "run_stride.h"
 
-#include "multiregion/ParallelSimulationManager.h"
+#include "multiregion/SequentialSimulationManager.h"
 #include "multiregion/SimulationManager.h"
 #include "multiregion/TravelModel.h"
 #include "output/CasesFile.h"
@@ -152,7 +152,7 @@ void run_stride(const MultiSimulationConfig& config)
 	// Create simulator.
 	// -----------------------------------------------------------------------------------------
 	Stopwatch<> total_clock("total_clock", true);
-	multiregion::ParallelSimulationManager<StrideSimulatorResult, multiregion::RegionId> sim_manager{num_threads};
+	multiregion::SequentialSimulationManager<StrideSimulatorResult, multiregion::RegionId> sim_manager{num_threads};
 
 	// Build all the simulations.
 	struct SimulationTuple

--- a/src/main/cpp/sim/run_stride.cpp
+++ b/src/main/cpp/sim/run_stride.cpp
@@ -185,18 +185,13 @@ void run_stride(const MultiSimulationConfig& config)
 	}
 	cout << "Done building simulators. " << endl << endl;
 
-	// Start all the simulations.
-	for (const auto& sim_tuple : tasks) {
-		sim_tuple.sim_task->Start();
-	}
+	// -----------------------------------------------------------------------------------------
+	// Run the simulation.
+	// -----------------------------------------------------------------------------------------
+	sim_manager.WaitAll();
 
-	// Wait for the simulations to complete and generate output files for them.
+	// Generate output files for the simulations.
 	for (const auto& sim_tuple : tasks) {
-		// -----------------------------------------------------------------------------------------
-		// Run the simulation.
-		// -----------------------------------------------------------------------------------------
-		sim_tuple.sim_task->Wait();
-
 		// -----------------------------------------------------------------------------------------
 		// Generate output files
 		// -----------------------------------------------------------------------------------------

--- a/src/main/cpp/sim/run_stride.cpp
+++ b/src/main/cpp/sim/run_stride.cpp
@@ -215,7 +215,7 @@ void run_stride(const MultiSimulationConfig& config)
 
 		// Persons
 		if (sim_tuple.sim_config.log_config->generate_person_file) {
-			auto pop = std::make_shared<Population>(sim_tuple.sim_task->GetPopulation());
+			auto pop = sim_tuple.sim_task->GetPopulation();
 			PersonFile person_file(sim_tuple.sim_output_prefix);
 			person_file.Print(pop);
 		}

--- a/src/main/cpp/sim/run_stride.cpp
+++ b/src/main/cpp/sim/run_stride.cpp
@@ -69,7 +69,7 @@ void StrideSimulatorResult::BeforeSimulatorStep(const Population&) { run_clock.S
 void StrideSimulatorResult::AfterSimulatorStep(const Population& pop)
 {
 	run_clock.Stop();
-	auto infected_count = pop.GetInfectedCount();
+	auto infected_count = pop.get_infected_count();
 	cases.push_back(infected_count);
 	day++;
 

--- a/src/main/cpp/sim/run_stride.cpp
+++ b/src/main/cpp/sim/run_stride.cpp
@@ -152,6 +152,8 @@ void run_stride(const MultiSimulationConfig& config)
 	// Create simulator.
 	// -----------------------------------------------------------------------------------------
 	Stopwatch<> total_clock("total_clock", true);
+	// multiregion::SequentialSimulationManager<StrideSimulatorResult, multiregion::RegionId> sim_manager{
+	//     num_threads};
 	multiregion::ParallelSimulationManager<StrideSimulatorResult, multiregion::RegionId> sim_manager{
 	    config.region_models.size(), num_threads};
 

--- a/src/main/cpp/util/Errors.h
+++ b/src/main/cpp/util/Errors.h
@@ -4,6 +4,6 @@
 #include <exception>
 #include <string>
 
-#define FATAL_ERROR(message) throw runtime_error(std::string(__func__) + "> " + (message))
+#define FATAL_ERROR(message) throw std::runtime_error(std::string(__func__) + "> " + (message))
 
 #endif // end-of-include-guard

--- a/src/main/cpp/util/InstallDirs.cpp
+++ b/src/main/cpp/util/InstallDirs.cpp
@@ -76,7 +76,7 @@ void InstallDirs::Initialize()
 		#elif defined(__linux__)
 			char exePath[PATH_MAX + 1];
 		        std::memset(exePath, 0, sizeof exePath);
-		        size_t size = ::readlink("/proc/self/exe", exePath, sizeof(exePath) - 1);
+		        std::size_t size = ::readlink("/proc/self/exe", exePath, sizeof(exePath) - 1);
 		        if (size > 0 && size != sizeof(exePath) - 1) {
                                 g_exec_path = canonical(system_complete(exePath));
 		        }

--- a/src/test/cpp/gtester/BatchRuns.cpp
+++ b/src/test/cpp/gtester/BatchRuns.cpp
@@ -18,6 +18,7 @@
  * Implementation of scenario tests running in batch mode.
  */
 
+#include "multiregion/Visitor.h"
 #include "pop/Population.h"
 #include "sim/Simulator.h"
 #include "sim/SimulatorBuilder.h"
@@ -34,6 +35,7 @@
 
 using namespace std;
 using namespace stride;
+using namespace stride::multiregion;
 using namespace ::testing;
 
 namespace Tests {
@@ -179,7 +181,7 @@ TEST_P( BatchDemos, Run )
 	// -----------------------------------------------------------------------------------------
 	const unsigned int num_days = pt_config.get<unsigned int>("run.num_days");
 	for (unsigned int i = 0; i < num_days; i++) {
-			sim->TimeStep();
+			sim->TimeStep(SimulationStepInput());
 	}
 
 	// -----------------------------------------------------------------------------------------

--- a/src/test/cpp/gtester/BatchRuns.cpp
+++ b/src/test/cpp/gtester/BatchRuns.cpp
@@ -190,7 +190,7 @@ TEST_P( BatchDemos, Run )
         // -----------------------------------------------------------------------------------------
 	// Round up.
         // -----------------------------------------------------------------------------------------
-	const unsigned int num_cases = sim->GetPopulation()->GetInfectedCount();
+	const unsigned int num_cases = sim->GetPopulation()->get_infected_count();
 	ASSERT_NEAR(num_cases, g_results.at(test_tag),10000) << "!! CHANGED !!";
 }
 

--- a/src/test/cpp/gtester/RunSimulator.cpp
+++ b/src/test/cpp/gtester/RunSimulator.cpp
@@ -17,4 +17,9 @@ TEST(RunSimulator, RunSimulatorMultiregion)
 	stride::run_stride(false, "../config/run_multiregion.xml");
 }
 
+TEST(RunSimulator, RunSimulatorTravel)
+{
+	stride::run_stride(false, "../config/run_travel_test.xml");
+}
+
 } // Tests


### PR DESCRIPTION
This PR turned out to be rather large. I implemented inter-region person transfer but had to change a lot of crucial data structures in the process.

I also got rid of a lot of baroque hacks and replaced them with "modern" C++ constructs.

For example, `Cluster` used to store raw pointers to `Person` in a `std::vector<std::pair<Person*, bool>>`. These `Person*` values would then point to locations in `Population`, which literally inherited from `std::vector<Person>` at the time. So a single `push_*`/`emplace_*`/`erase`/`emplace`/`insert` on the simulator's `Population` can cause the clusters to segfault because the `Population`/`std::vector<Person>` might reallocate its underlying buffer.

`Population` contains (but does not inherit from!) an `std::map` now (apparently, changing the ordering of a `Population` makes the simulator spit out entirely different results). `Person*`/`Person&` have been replaced by `Person`, which is now a pair that consists of an (immutable) id and an `std::shared_ptr<PersonData>`. `PersonData` is a mutable data structure.

In other news: I included only one unit test for this PR. It checks that multi-region simulations do not segfault. Incidentally, I consider that to be my crowning achievement. The sheer amount of hacks and poorly-maintained invariants in the stride codebase have resulted in a veritable cascade of segfaults and other hard-to-detect bugs. But the refactors I made don't actually add new functionality. So they should really be covered by pre-existing tests.