### PR TITLE
Disarm the forkbomb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ matrix:
             - clang-3.8
             - clang++-3.8
             - libstdc++-6-dev
+            - libiomp-dev
 
 before_install:
   - export CXX="$CXX_COMPILER_NAME" CC="$CC_COMPILER_NAME"

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,6 @@ matrix:
             - clang-3.8
             - clang++-3.8
             - libstdc++-6-dev
-            - libiomp-dev
 
 before_install:
   - export CXX="$CXX_COMPILER_NAME" CC="$CC_COMPILER_NAME"

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,9 @@ endif
 ifeq ($(BUILD_DIR),)
 	BUILD_DIR = ./build
 endif
+ifeq ($(PARALLEL_MAKE),)
+	PARALLEL_MAKE = 4
+endif
 
 #============================================================================
 #   Targets


### PR DESCRIPTION
This PR sets `PARALLEL_MAKE` to `4`. Hopefully, this will keep our Travis builds from crashing due to resource exhaustion.