### PR TITLE
Have Travis maintain a gtest report comparison table

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ before_install:
   # Print the CMake version.
   - cmake --version
   # Grab the gtest report pretty printer.
-  - wget https://github.com/jonathanvdc/gtest-report-tools/releases/download/v0.1.1/gtest-report-tools.zip
+  - wget https://github.com/jonathanvdc/gtest-report-tools/releases/download/v0.1.2/gtest-report-tools.zip
   - unzip gtest-report-tools.zip -d gtest-report-tools
   # Build and install boost.
   - echo "using mpi ;" > ~/site-config.jam

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ before_install:
   - export LD_LIBRARY_PATH=$HOME/boost_1_63_0/stage/lib:$LD_LIBRARY_PATH
   
   # Build and install Poco
-  - mkdir $HOME/poco
+  - mkdir -p $HOME/poco
   - wget https://pocoproject.org/releases/poco-1.7.8/poco-1.7.8p2.tar.gz
   - tar -xzf poco-1.7.8p2.tar.gz -C $HOME/poco
   - pushd $HOME/poco/poco-1.7.8p2

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ cache:
     # Cache the boost install
     - $HOME/boost_1_63_0/boost
     - $HOME/boost_1_63_0/stage/lib
+    - $HOME/poco
 
 # We're going to need cmake, MPI and the mono runtime.
 addons:
@@ -70,15 +71,15 @@ before_install:
   - export LD_LIBRARY_PATH=$HOME/boost_1_63_0/stage/lib:$LD_LIBRARY_PATH
   
   # Build and install Poco
+  - mkdir $HOME/poco
   - wget https://pocoproject.org/releases/poco-1.7.8/poco-1.7.8p2.tar.gz
-  - gunzip poco-1.7.8p2.tar.gz
-  - tar -xf poco-1.7.8p2.tar
-  - cd poco-1.7.8p2
+  - tar -xzf poco-1.7.8p2.tar.gz -C $HOME/poco
+  - pushd $HOME/poco/poco-1.7.8p2
   - ./configure
   - make -s
   - export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
   - sudo make -s install
-  - cd ..
+  - popd
 
 script:
   # `make all; make test`, but fancier.

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ script:
   # `make all; make test`, but fancier.
   - make all
   - make test_all
-  # Pretty-print the test results.
-  - mono gtest-report-tools/gtest-report-print.exe --ansi build/installed/bin/gtester_all.xml
   # Push the report to our website.
   - ./push-report.sh
+  # Pretty-print the test results.
+  - mono gtest-report-tools/gtest-report-print.exe --ansi build/installed/bin/gtester_all.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,3 +86,5 @@ script:
   - make test_all
   # Pretty-print the test results.
   - mono gtest-report-tools/gtest-report-print.exe --ansi build/installed/tests/gtester_all.xml
+  # Push the report to our website.
+  - ./push-report.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ before_install:
   # Print the CMake version.
   - cmake --version
   # Grab the gtest report pretty printer.
-  - wget https://github.com/jonathanvdc/gtest-report-tools/releases/download/v0.1.2/gtest-report-tools.zip
+  - wget https://github.com/jonathanvdc/gtest-report-tools/releases/download/v0.1.3/gtest-report-tools.zip
   - unzip gtest-report-tools.zip -d gtest-report-tools
   # Build and install boost.
   - echo "using mpi ;" > ~/site-config.jam

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,8 +60,12 @@ matrix:
 
 before_install:
   - export CXX="$CXX_COMPILER_NAME" CC="$CC_COMPILER_NAME"
+  # Print the C++ compiler version.
+  - $CXX --version
   # Print the CMake version.
   - cmake --version
+  # Print the Mono version number.
+  - mono --version
   # Grab the gtest report pretty printer.
   - wget https://github.com/jonathanvdc/gtest-report-tools/releases/download/v0.1.3/gtest-report-tools.zip
   - unzip gtest-report-tools.zip -d gtest-report-tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ addons:
   apt:
     packages: &default_packages
       - mono-runtime
+      - libmono-corlib2.0-cil
+      - libmono-corlib4.0-cil
+      - libmono-corlib4.5-cil
       - libmono-system-xml4.0-cil
       - libmono-system-core4.0-cil
       - cmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,6 @@ script:
   - make all
   - make test_all
   # Pretty-print the test results.
-  - mono gtest-report-tools/gtest-report-print.exe --ansi build/installed/tests/gtester_all.xml
+  - mono gtest-report-tools/gtest-report-print.exe --ansi build/installed/bin/gtester_all.xml
   # Push the report to our website.
   - ./push-report.sh

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,7 @@ test installcheck: install_test
 	$(MAKE) -C $(BUILD_DIR)/test --no-print-directory run_ctest
 
 test_all: install_test
-	$(MAKE) -C $(BUILD_DIR)/test --no-print-directory run_ctest_all
+	cd build/installed/bin/; \
+	./gtester --gtest_output=xml:gtester_all.xml
 	
 #############################################################################

--- a/push-report.sh
+++ b/push-report.sh
@@ -25,6 +25,7 @@ cd ..
 
 # Copy our gtest report to out/gtest-reports/CONTRIBUTOR-BRANCH-COMPILER.xml
 REPO_OWNER_NAME=$(echo $TRAVIS_REPO_SLUG | cut -d '/' -f1)
+mkdir -p out/gtest-reports
 cp build/installed/bin/gtester_all.xml out/gtest-reports/${REPO_OWNER_NAME}-${TRAVIS_BRANCH}-${CC_COMPILER_NAME}.xml
 
 # Create a table comparison of all reports.

--- a/push-report.sh
+++ b/push-report.sh
@@ -32,7 +32,8 @@ cp build/installed/bin/gtester_all.xml out/gtest-reports/${REPO_OWNER_NAME}-${TR
 
 # Create a table comparison of all reports.
 echo "Regenerating comparison table..."
-mono gtest-report-tools/gtest-report-html.exe out/gtest-reports/*.xml --css=gtest-report-tools/resources/simple-style.css | tee out/gtest-reports/comparison.html
+mono gtest-report-tools/gtest-report-html.exe out/gtest-reports/*.xml --css=gtest-report-tools/resources/simple-style.css \
+    > out/gtest-reports/comparison.html
 
 # Now let's go have some fun with the cloned repo
 cd out

--- a/push-report.sh
+++ b/push-report.sh
@@ -18,22 +18,27 @@ SHA=`git rev-parse --verify HEAD`
 
 # Clone the existing gh-pages for this repo into out/
 # Create a new empty branch if gh-pages doesn't exist yet (should only happen on first deploy)
+echo "Cloning flu-plus-plus.github.io repository..."
 git clone $REPO out
 cd out
 git checkout $TARGET_BRANCH || git checkout --orphan $TARGET_BRANCH
 cd ..
 
 # Copy our gtest report to out/gtest-reports/CONTRIBUTOR-BRANCH-COMPILER.xml
+echo "Copying gtest report to flu-plus-plus.github.io/gtest-reports/ ..."
 REPO_OWNER_NAME=$(echo $TRAVIS_REPO_SLUG | cut -d '/' -f1)
 mkdir -p out/gtest-reports
 cp build/installed/bin/gtester_all.xml out/gtest-reports/${REPO_OWNER_NAME}-${TRAVIS_BRANCH}-${CC_COMPILER_NAME}.xml
 
 # Create a table comparison of all reports.
+echo "Regenerating comparison table..."
 mono gtest-report-tools/gtest-report-html.exe out/gtest-reports/*.xml --css=gtest-report-tools/resources/simple-css.css \
     > out/gtest-reports/comparison.html
 
 # Now let's go have some fun with the cloned repo
 cd out
+
+echo "Configuring user..."
 git config user.name "FluBot"
 git config user.email "flu-plus-plus-flubot@outlook.com"
 
@@ -45,8 +50,11 @@ fi
 
 # Commit the "changes", i.e. the new version.
 # The delta will show diffs between new and old versions.
+echo "Committing changes..."
 git add .
 git commit -m "Deploy to GitHub Pages: ${SHA}"
 
 # Now that we're all set up, we can push.
+echo "Pushing commit..."
 git push $PASSWORD_REPO $TARGET_BRANCH
+echo "Pushed commit"

--- a/push-report.sh
+++ b/push-report.sh
@@ -41,8 +41,10 @@ echo "Configuring user..."
 git config user.name "FluBot"
 git config user.email "flu-plus-plus-flubot@outlook.com"
 
+git add .
+
 # If there are no changes to the compiled out (e.g. this is a README update) then just bail.
-if [ -z `git diff --exit-code` ]; then
+if [ -z `git diff --cached --exit-code` ]; then
     echo "No changes to the output on this push; exiting."
     exit 0
 fi
@@ -50,7 +52,6 @@ fi
 # Commit the "changes", i.e. the new version.
 # The delta will show diffs between new and old versions.
 echo "Committing changes..."
-git add .
 git commit -m "Deploy to GitHub Pages: ${SHA}"
 
 # Now that we're all set up, we can push.

--- a/push-report.sh
+++ b/push-report.sh
@@ -44,7 +44,7 @@ git config user.email "flu-plus-plus-flubot@outlook.com"
 git add .
 
 # If there are no changes to the compiled out (e.g. this is a README update) then just bail.
-if ! git diff --cached --exit-code; then
+if git diff --cached --exit-code; then
     echo "No changes to the output on this push; exiting."
     exit 0
 fi

--- a/push-report.sh
+++ b/push-report.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -e # Exit with nonzero exit code if anything fails
+
+# This file is based on the tutorial here: https://gist.github.com/domenic/ec8b0fc8ab45f39403dd
+
+TARGET_BRANCH="master"
+
+# Pull requests and commits to other branches shouldn't try to deploy, just build to verify
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+    echo "Skipping deploy."
+    exit 0
+fi
+
+# Save some useful information
+REPO="https://github.com/flu-plus-plus/flu-plus-plus.github.io"
+PASSWORD_REPO="https://flubot:${FLUBOT_PASSWORD}@github.com/flu-plus-plus/flu-plus-plus.github.io"
+SHA=`git rev-parse --verify HEAD`
+
+# Clone the existing gh-pages for this repo into out/
+# Create a new empty branch if gh-pages doesn't exist yet (should only happen on first deploy)
+git clone $REPO out
+cd out
+git checkout $TARGET_BRANCH || git checkout --orphan $TARGET_BRANCH
+cd ..
+
+# Copy our gtest report to out/gtest-reports/CONTRIBUTOR-BRANCH-COMPILER.xml
+REPO_OWNER_NAME=$(echo $TRAVIS_REPO_SLUG | cut -d '/' -f1)
+cp build/installed/bin/gtester_all.xml out/gtest-reports/${REPO_OWNER_NAME}-${TRAVIS_BRANCH}-${CC_COMPILER_NAME}.xml
+
+# Create a table comparison of all reports.
+mono gtest-report-tools/gtest-report-html.exe out/gtest-reports/*.xml --css=gtest-report-tools/resources/simple-css.css \
+    > out/gtest-reports/comparison.html
+
+# Now let's go have some fun with the cloned repo
+cd out
+git config user.name "FluBot"
+git config user.email "flu-plus-plus-flubot@outlook.com"
+
+# If there are no changes to the compiled out (e.g. this is a README update) then just bail.
+if [ -z `git diff --exit-code` ]; then
+    echo "No changes to the output on this push; exiting."
+    exit 0
+fi
+
+# Commit the "changes", i.e. the new version.
+# The delta will show diffs between new and old versions.
+git add .
+git commit -m "Deploy to GitHub Pages: ${SHA}"
+
+# Now that we're all set up, we can push.
+git push $PASSWORD_REPO $TARGET_BRANCH

--- a/push-report.sh
+++ b/push-report.sh
@@ -32,8 +32,8 @@ cp build/installed/bin/gtester_all.xml out/gtest-reports/${REPO_OWNER_NAME}-${TR
 
 # Create a table comparison of all reports.
 echo "Regenerating comparison table..."
-mono gtest-report-tools/gtest-report-html.exe out/gtest-reports/*.xml --css=gtest-report-tools/resources/simple-css.css \
-    > out/gtest-reports/comparison.html
+mono gtest-report-tools/gtest-report-html.exe out/gtest-reports/*.xml --css=gtest-report-tools/resources/simple-style.css \
+    1> out/gtest-reports/comparison.html
 
 # Now let's go have some fun with the cloned repo
 cd out

--- a/push-report.sh
+++ b/push-report.sh
@@ -44,7 +44,7 @@ git config user.email "flu-plus-plus-flubot@outlook.com"
 git add .
 
 # If there are no changes to the compiled out (e.g. this is a README update) then just bail.
-if [ -z `git diff --cached --exit-code` ]; then
+if ! git diff --cached --exit-code; then
     echo "No changes to the output on this push; exiting."
     exit 0
 fi

--- a/push-report.sh
+++ b/push-report.sh
@@ -32,8 +32,7 @@ cp build/installed/bin/gtester_all.xml out/gtest-reports/${REPO_OWNER_NAME}-${TR
 
 # Create a table comparison of all reports.
 echo "Regenerating comparison table..."
-mono gtest-report-tools/gtest-report-html.exe out/gtest-reports/*.xml --css=gtest-report-tools/resources/simple-style.css \
-    1> out/gtest-reports/comparison.html
+mono gtest-report-tools/gtest-report-html.exe out/gtest-reports/*.xml --css=gtest-report-tools/resources/simple-style.css | tee out/gtest-reports/comparison.html
 
 # Now let's go have some fun with the cloned repo
 cd out

--- a/push-report.sh
+++ b/push-report.sh
@@ -53,7 +53,7 @@ fi
 # Commit the "changes", i.e. the new version.
 # The delta will show diffs between new and old versions.
 echo "Committing changes..."
-git commit -m "Deploy to GitHub Pages: ${SHA}"
+git commit -m "Deploy comparison table to github.io: ${SHA}"
 
 # Now that we're all set up, we can push.
 echo "Pushing commit..."


### PR DESCRIPTION
This PR will make Travis maintain a table that compares gtest reports for all the forks. All you have to do to opt-in is set the `FLUBOT_PASSWORD` environment variable in the Travis UI (**don't** add it to the `.travis.yml`!). Going forward from that, Travis CI will automagically update the comparison table at [flu-plus-plus.github.io/gtest-reports/comparison.html](https://flu-plus-plus.github.io/gtest-reports/comparison.html).

Caveat: like Elvis Presley and diamonds, branches in the test report live forever even if they become stale or get deleted. The comparison table will get crowded if we create lots of individual branches. So, um, try to avoid that. Okay?

(Also, I made Travis cache POCO.)