### PR TITLE
Move out of the toolchain stone age

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - mono
           packages:
             - *default_packages
             - gcc-6
@@ -52,6 +53,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-trusty-4.0
+            - mono
           packages:
             - *default_packages
             - clang-4.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,17 +49,17 @@ matrix:
             - g++-6
 
     - compiler: clang
-      env: CC_COMPILER_NAME='clang-4.0' CXX_COMPILER_NAME='clang++-4.0'
+      env: CC_COMPILER_NAME='clang-3.8' CXX_COMPILER_NAME='clang++-3.8'
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-4.0
+            - llvm-toolchain-trusty
             - mono
           packages:
             - *default_packages
-            - clang-4.0
-            - clang++-4.0
+            - clang-3.8
+            - clang++-3.8
             - libstdc++-6-dev
             - libiomp-dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,6 @@ matrix:
             - clang-4.0
             - clang++-4.0
             - libstdc++-6-dev
-            - libiomp
 
 before_install:
   - export CXX="$CXX_COMPILER_NAME" CC="$CC_COMPILER_NAME"

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ matrix:
             - clang-4.0
             - clang++-4.0
             - libstdc++-6-dev
+            - libiomp-dev
 
 before_install:
   - export CXX="$CXX_COMPILER_NAME" CC="$CC_COMPILER_NAME"

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ before_install:
   # Grab a relatively recent version of CMake, unzip it and add
   # it to the path.
   - wget https://cmake.org/files/v3.5/cmake-3.5.2-Linux-x86_64.tar.gz
-  - tar -xvf cmake-3.5.2-Linux-x86_64.tar.gz
+  - tar -xzf cmake-3.5.2-Linux-x86_64.tar.gz
   - export PATH="$PWD/cmake-3.5.2-Linux-x86_64/bin/:$PATH"
   # Print the CMake version.
   - cmake --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
     - $HOME/boost_1_63_0/stage/lib
     - $HOME/poco
 
-# We're going to need cmake, MPI and the mono runtime.
+# We're going to need MPI and the mono runtime.
 addons:
   apt:
     packages: &default_packages
@@ -25,9 +25,11 @@ addons:
       - libmono-corlib4.5-cil
       - libmono-system-xml4.0-cil
       - libmono-system-core4.0-cil
-      - cmake
       - mpich
       - libmpich-dev
+      # The CMake package is kind of dated. We'll download a later version
+      # of cmake later on.
+      # - cmake
       # Don't grab the APT boost package, because that package is stale.
       # We'll need to build boost ourselves.
       # - libboost-all-dev
@@ -40,7 +42,6 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - kalakris-cmake
             - mono
           packages:
             - *default_packages
@@ -54,7 +55,6 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-trusty-4.0
-            - kalakris-cmake
             - mono
           packages:
             - *default_packages
@@ -66,10 +66,15 @@ before_install:
   - export CXX="$CXX_COMPILER_NAME" CC="$CC_COMPILER_NAME"
   # Print the C++ compiler version.
   - $CXX --version
-  # Print the CMake version.
-  - cmake --version
   # Print the Mono version number.
   - mono --version
+  # Grab a relatively recent version of CMake, unzip it and add
+  # it to the path.
+  - wget https://cmake.org/files/v3.5/cmake-3.5.2-Linux-x86_64.tar.gz
+  - tar -xvf cmake-3.5.2-Linux-x86_64.tar.gz
+  - export PATH="$PWD/cmake-3.5.2-Linux-x86_64/bin/:$PATH"
+  # Print the CMake version.
+  - cmake --version
   # Grab the gtest report pretty printer.
   - wget https://github.com/jonathanvdc/gtest-report-tools/releases/download/v0.1.3/gtest-report-tools.zip
   - unzip gtest-report-tools.zip -d gtest-report-tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,17 +49,17 @@ matrix:
             - g++-6
 
     - compiler: clang
-      env: CC_COMPILER_NAME='clang-3.8' CXX_COMPILER_NAME='clang++-3.8'
+      env: CC_COMPILER_NAME='clang-4.0' CXX_COMPILER_NAME='clang++-4.0'
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty
+            - llvm-toolchain-trusty-4.0
             - mono
           packages:
             - *default_packages
-            - clang-3.8
-            - clang++-3.8
+            - clang-4.0
+            - clang++-4.0
             - libstdc++-6-dev
             - libiomp-dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,17 +46,18 @@ matrix:
             - g++-6
 
     - compiler: clang
-      env: CC_COMPILER_NAME='clang-3.8' CXX_COMPILER_NAME='clang++-3.8'
+      env: CC_COMPILER_NAME='clang-4.0' CXX_COMPILER_NAME='clang++-4.0'
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty
+            - llvm-toolchain-trusty-4.0
           packages:
             - *default_packages
-            - clang-3.8
-            - clang++-3.8
+            - clang-4.0
+            - clang++-4.0
             - libstdc++-6-dev
+            - libiomp
 
 before_install:
   - export CXX="$CXX_COMPILER_NAME" CC="$CC_COMPILER_NAME"

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,9 +71,9 @@ before_install:
   - mono --version
   # Grab a relatively recent version of CMake, unzip it and add
   # it to the path.
-  - wget https://cmake.org/files/v3.5/cmake-3.5.2-Linux-x86_64.tar.gz
-  - tar -xzf cmake-3.5.2-Linux-x86_64.tar.gz
-  - export PATH="$PWD/cmake-3.5.2-Linux-x86_64/bin/:$PATH"
+  - wget https://cmake.org/files/v3.8/cmake-3.8.0-Linux-x86_64.tar.gz
+  - tar -xzf cmake-3.8.0-Linux-x86_64.tar.gz
+  - export PATH="$PWD/cmake-3.8.0-Linux-x86_64/bin/:$PATH"
   # Print the CMake version.
   - cmake --version
   # Grab the gtest report pretty printer.

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - kalakris-cmake
             - mono
           packages:
             - *default_packages
@@ -53,6 +54,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-trusty-4.0
+            - kalakris-cmake
             - mono
           packages:
             - *default_packages


### PR DESCRIPTION
I've upgraded Travis' `clang` to version `4.0` and `cmake` to version `3.8`. OpenMP still doesn't work, but at least we tried. That's all there is to this PR, I guess.