### PR TITLE
Convert travel models to boost graphs

### DIFF
--- a/src/main/cpp/calendar/Calendar.h
+++ b/src/main/cpp/calendar/Calendar.h
@@ -80,6 +80,8 @@ private:
 	std::vector<boost::gregorian::date>    m_school_holidays;         ///< Vector of school holidays
 };
 
+using CalendarRef = std::shared_ptr<const Calendar>;
+
 } // end_of_namespace
 
 #endif // end of include guard

--- a/src/main/cpp/core/Infector.cpp
+++ b/src/main/cpp/core/Infector.cpp
@@ -64,7 +64,7 @@ class LOG_POLICY
 {
 public:
         static void Execute(const shared_ptr<spdlog::logger>& logger, const Person& p1, const Person& p2,
-                ClusterType cluster_type, const shared_ptr<const Calendar>& environ)
+                ClusterType cluster_type, const CalendarRef& environ)
         {}
 };
 
@@ -76,7 +76,7 @@ class LOG_POLICY<LogMode::Transmissions>
 {
 public:
         static void Execute(const shared_ptr<spdlog::logger>& logger, const Person& p1, const Person& p2,
-                ClusterType cluster_type, const shared_ptr<const Calendar>& environ)
+                ClusterType cluster_type, const CalendarRef& environ)
         {
                 logger->info("[TRAN] {} {} {} {}",
                        p1.GetId(), p2.GetId(), ToString(cluster_type), environ->GetSimulationDay());
@@ -91,7 +91,7 @@ class LOG_POLICY<LogMode::Contacts>
 {
 public:
         static void Execute(const shared_ptr<spdlog::logger>& logger, const Person& p1, const Person& p2,
-                ClusterType cluster_type, const shared_ptr<const Calendar>& calendar)
+                ClusterType cluster_type, const CalendarRef& calendar)
         {
                 unsigned int home                 = (cluster_type == ClusterType::Household);
                 unsigned int work                 = (cluster_type == ClusterType::Work);
@@ -112,7 +112,7 @@ public:
 template<LogMode log_level, bool track_index_case>
 void Infector<log_level, track_index_case>::Execute(
         Cluster& cluster, DiseaseProfile disease_profile,
-        RngHandler& contact_handler, const shared_ptr<const Calendar>& calendar,
+        RngHandler& contact_handler, const CalendarRef& calendar,
         const std::shared_ptr<spdlog::logger>& log)
 {
         // check if the cluster has infected members and sort
@@ -160,7 +160,7 @@ void Infector<log_level, track_index_case>::Execute(
 template<bool track_index_case>
 void Infector<LogMode::Contacts, track_index_case>::Execute(
         Cluster& cluster, DiseaseProfile disease_profile,
-        RngHandler& contact_handler, const shared_ptr<const Calendar>& calendar,
+        RngHandler& contact_handler, const CalendarRef& calendar,
         const std::shared_ptr<spdlog::logger>& log)
 {
         cluster.UpdateMemberPresence();

--- a/src/main/cpp/core/Infector.cpp
+++ b/src/main/cpp/core/Infector.cpp
@@ -133,13 +133,13 @@ void Infector<log_level, track_index_case>::Execute(
                 for (size_t i_infected = 0; i_infected < num_cases; i_infected++) {
                         // check if member is present today
                         if (c_members[i_infected].second) {
-                                const auto p1 = c_members[i_infected].first;
+                                const auto& p1 = c_members[i_infected].first;
                                 if (p1.GetHealth().IsInfectious()) {
                                         const double contact_rate = cluster.GetContactRate(p1);
                                         for (size_t i_contact = num_cases; i_contact < c_immune; i_contact++) {
                                                 // check if member is present today
                                                 if (c_members[i_contact].second) {
-                                                        auto p2 = c_members[i_contact].first;
+                                                        const auto& p2 = c_members[i_contact].first;
                                                         if (contact_handler.HasTransmission(contact_rate, transmission_rate)) {
                                                                 LOG_POLICY<log_level>::Execute(log, p1, p2, c_type, calendar);
                                                                 p2.GetHealth().StartInfection();
@@ -174,12 +174,12 @@ void Infector<LogMode::Contacts, track_index_case>::Execute(
         for (size_t i_person1 = 0; i_person1 < cluster.m_members.size(); i_person1++) {
                 // check if member participates in the social contact survey && member is present today
                 if (c_members[i_person1].second && c_members[i_person1].first.IsParticipatingInSurvey()) {
-                        auto p1 = c_members[i_person1].first;
+                        const auto& p1 = c_members[i_person1].first;
                         const double contact_rate = cluster.GetContactRate(p1);
                         for (size_t i_person2 = 0; i_person2 < c_members.size(); i_person2++) {
                                 // check if member is present today
                                 if ((i_person1 != i_person2) && c_members[i_person2].second) {
-                                        auto p2 = c_members[i_person2].first;
+                                        const auto& p2 = c_members[i_person2].first;
                                         // check for contact
                                         if (contact_handler.HasContact(contact_rate)) {
                                                 // TODO ContactHandler doesn't have a separate transmission function anymore to

--- a/src/main/cpp/core/Infector.h
+++ b/src/main/cpp/core/Infector.h
@@ -41,7 +41,7 @@ class Infector
 public:
 	///
 	static void Execute(Cluster& cluster, DiseaseProfile disease_profile,
-	        RngHandler& contact_handler, const std::shared_ptr<const Calendar>& sim_state,
+	        RngHandler& contact_handler, const CalendarRef& sim_state,
                 const std::shared_ptr<spdlog::logger>& log);
 };
 
@@ -54,7 +54,7 @@ class Infector<LogMode::Contacts, track_index_case>
 public:
         ///
         static void Execute(Cluster& cluster, DiseaseProfile disease_profile,
-                RngHandler& contact_handler, const std::shared_ptr<const Calendar>& calendar,
+                RngHandler& contact_handler, const CalendarRef& calendar,
                 const std::shared_ptr<spdlog::logger>& log);
 };
 

--- a/src/main/cpp/multiregion/TravelModel.h
+++ b/src/main/cpp/multiregion/TravelModel.h
@@ -9,6 +9,8 @@
 #include <memory>
 #include <unordered_set>
 #include <vector>
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/graph_traits.hpp>
 #include <boost/property_tree/ptree.hpp>
 
 namespace stride {
@@ -36,7 +38,19 @@ struct AirRoute final
 };
 
 /**
- * Describes information pertaining to an airport.
+ * Describes an airport's region ID and passenger fraction.
+ */
+struct AirportDescription final
+{
+	/// The id of the region where this airport is located.
+	RegionId region_id;
+
+	/// The fraction of passengers in the region that use this airport.
+	double passenger_fraction;
+};
+
+/**
+ * Describes an airport's region ID, passenger fraction and routes.
  */
 struct Airport final
 {
@@ -45,6 +59,9 @@ struct Airport final
 
 	/// The fraction of passengers in the region that use this airport.
 	double passenger_fraction;
+
+	/// Gets this airport's description.
+	AirportDescription GetDescription() const { return {region_id, passenger_fraction}; }
 
 	/// Gets the list of all outgoing routes that start at this airport.
 	std::vector<AirRoute> routes;
@@ -107,6 +124,13 @@ public:
 	/// range.
 	static std::vector<RegionTravelRef> ParseRegionTravel(
 	    const boost::property_tree::ptree& ptree, RegionId first_region_id = 0);
+
+	using BoostEdgeWeightProperty = boost::property<boost::edge_weight_t, double>;
+	using BoostGraph = boost::adjacency_list<
+	    boost::vecS, boost::vecS, boost::directedS, AirportDescription, BoostEdgeWeightProperty>;
+
+	/// Creates a boost graph that is equivalent to the graph defined by this travel model.
+	BoostGraph ToBoostGraph() const;
 
 private:
 	RegionId region_id;

--- a/src/main/cpp/sim/Simulator.cpp
+++ b/src/main/cpp/sim/Simulator.cpp
@@ -139,34 +139,38 @@ void Simulator::RemovePersonFromClusters(const Person& person)
 
 PersonId Simulator::GeneratePersonId()
 {
-	// TODO: recycle ids
-	return m_population->get_max_id() + 1;
+	if (m_unused_person_ids.empty()) {
+		return m_population->get_max_id() + 1;
+	} else {
+		auto result = m_unused_person_ids.front();
+		m_unused_person_ids.pop();
+		return result;
+	}
 }
 
 std::size_t Simulator::GenerateHousehold()
 {
-	// TODO: recycle households
-	auto household_id = m_households.size();
-	m_households.emplace_back(household_id, ClusterType::Household);
+	std::size_t household_id;
+	if (m_unused_households.empty()) {
+		household_id = m_households.size();
+		m_households.emplace_back(household_id, ClusterType::Household);
+	} else {
+		household_id = m_unused_households.front();
+		m_unused_households.pop();
+	}
 	return household_id;
 }
 
-void Simulator::RecyclePersonId(PersonId id)
-{
-	// TODO: recycle ids
-}
+void Simulator::RecyclePersonId(PersonId id) { m_unused_person_ids.push(id); }
 
-void Simulator::RecycleHousehold(std::size_t household_id)
-{
-	// TODO: recycle households
-}
+void Simulator::RecycleHousehold(std::size_t household_id) { m_unused_households.push(household_id); }
 
 void Simulator::AcceptVisitors(const multiregion::SimulationStepInput& input)
 {
 	for (const auto& returning_expat : input.expatriates) {
 		// Return the expatriate to this region's population.
-		const auto& home_expat = *m_population->emplace(
-			m_expatriates.ExtractExpatriate(returning_expat.GetId()));
+		const auto& home_expat =
+		    *m_population->emplace(m_expatriates.ExtractExpatriate(returning_expat.GetId()));
 
 		// Update the expatriate's stats.
 		home_expat.GetHealth() = returning_expat.GetHealth();

--- a/src/main/cpp/sim/Simulator.cpp
+++ b/src/main/cpp/sim/Simulator.cpp
@@ -165,18 +165,17 @@ void Simulator::AcceptVisitors(const multiregion::SimulationStepInput& input)
 {
 	for (const auto& returning_expat : input.expatriates) {
 		// Return the expatriate to this region's population.
-		auto returned_expat = *m_population->emplace(returning_expat);
+		const auto& home_expat = *m_population->emplace(
+			m_expatriates.ExtractExpatriate(returning_expat.GetId()));
 
-		auto home_expat = m_expatriates.ExtractExpatriate(returning_expat.GetId());
-
-		// Update the returning expatriate's clusters.
-		for (std::size_t i = 0; i < NumOfClusterTypes(); i++) {
-			auto cluster_type = static_cast<ClusterType>(i);
-			returned_expat.GetClusterId(cluster_type) = home_expat.GetClusterId(cluster_type);
+		// Update the expatriate's stats.
+		home_expat.GetHealth() = returning_expat.GetHealth();
+		if (returning_expat.IsParticipatingInSurvey()) {
+			home_expat.ParticipateInSurvey();
 		}
 
 		// Add the returning expatriate to their clusters.
-		AddPersonToClusters(returned_expat);
+		AddPersonToClusters(home_expat);
 	}
 
 	for (const auto& visitor : input.visitors) {

--- a/src/main/cpp/sim/Simulator.h
+++ b/src/main/cpp/sim/Simulator.h
@@ -31,6 +31,7 @@
 #include "sim/SimulationConfig.h"
 
 #include <memory>
+#include <queue>
 #include <vector>
 #include <boost/property_tree/ptree.hpp>
 #include <spdlog/spdlog.h>
@@ -114,6 +115,9 @@ private:
 	std::vector<Cluster> m_work_clusters;       ///< Container with work Clusters.
 	std::vector<Cluster> m_primary_community;   ///< Container with primary community Clusters.
 	std::vector<Cluster> m_secondary_community; ///< Container with secondary community  Clusters.
+
+	std::queue<std::size_t> m_unused_households; ///< A list of unused households which can are eligible for recycling.
+	std::queue<PersonId> m_unused_person_ids; ///< A list of unused person IDs which are eligible for recycling.
 
 	DiseaseProfile m_disease_profile; ///< Profile of disease.
 

--- a/src/test/cpp/gtester/CMakeLists.txt
+++ b/src/test/cpp/gtester/CMakeLists.txt
@@ -28,6 +28,7 @@ set( SRC
 		ParseTravelConfig.cpp
 		MpiTests.cpp
 		RunSimulator.cpp
+		TravelModelGraph.cpp
 )
 
 if( Poco_FOUND )

--- a/src/test/cpp/gtester/TravelModelGraph.cpp
+++ b/src/test/cpp/gtester/TravelModelGraph.cpp
@@ -39,9 +39,9 @@ TEST(TravelModelGraph, VerifyBoostGraph)
 	auto boost_graph = first_region_travel_model->ToBoostGraph();
 	using BoostGraph = decltype(boost_graph);
 	ASSERT_EQ(boost_graph[0].region_id, 0u);
-	ASSERT_DOUBLE_EQ(boost_graph[0].passenger_fraction, 0.01);
+	ASSERT_DOUBLE_EQ(boost_graph[0].passenger_fraction, 2.0);
 	ASSERT_EQ(boost_graph[1].region_id, 1u);
-	ASSERT_DOUBLE_EQ(boost_graph[1].passenger_fraction, 0.01);
+	ASSERT_DOUBLE_EQ(boost_graph[1].passenger_fraction, 1.0);
 
 	boost::property_map<BoostGraph, boost::edge_weight_t>::type edge_weight_map =
 	    get(boost::edge_weight_t(), boost_graph);
@@ -50,7 +50,7 @@ TEST(TravelModelGraph, VerifyBoostGraph)
 
 	ASSERT_TRUE(route1.second);
 	ASSERT_TRUE(route2.second);
-	ASSERT_DOUBLE_EQ(edge_weight_map[route1.first], 2.0);
+	ASSERT_DOUBLE_EQ(edge_weight_map[route1.first], 3.0);
 	ASSERT_DOUBLE_EQ(edge_weight_map[route2.first], 1.0);
 }
 

--- a/src/test/cpp/gtester/TravelModelGraph.cpp
+++ b/src/test/cpp/gtester/TravelModelGraph.cpp
@@ -1,0 +1,57 @@
+#include <iostream>
+#include <boost/filesystem.hpp>
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/graph_traits.hpp>
+#include <boost/property_tree/exceptions.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/xml_parser.hpp>
+#include <gtest/gtest.h>
+#include "core/LogMode.h"
+#include "multiregion/TravelModel.h"
+
+namespace Tests {
+
+TEST(TravelModelGraph, VerifyBoostGraph)
+{
+	// First, parse the default travel model.
+
+	// <travel_model>
+	//     <region population_file="pop_nassau.csv" travel_fraction="0.01">
+	//         <airport name="JFK" passenger_fraction="2">
+	//             <route passenger_fraction="3">FDR</route>
+	//         </airport>
+	//     </region>
+	//     <region population_file="pop_oklahoma.csv" travel_fraction="0.01">
+	//         <airport name="FDR">
+	//             <route>JFK</route>
+	//         </airport>
+	//     </region>
+	// </travel_model>
+
+	std::ifstream pop_file{"../data/travel_test.xml"};
+	boost::property_tree::ptree pt;
+	boost::property_tree::read_xml(pop_file, pt);
+	auto travel_model = stride::multiregion::RegionTravel::ParseRegionTravel(pt.get_child("travel_model"));
+	auto first_region_travel_model = travel_model[0];
+
+	// Next, convert it to a boost graph.
+
+	auto boost_graph = first_region_travel_model->ToBoostGraph();
+	using BoostGraph = decltype(boost_graph);
+	ASSERT_EQ(boost_graph[0].region_id, 0u);
+	ASSERT_DOUBLE_EQ(boost_graph[0].passenger_fraction, 0.01);
+	ASSERT_EQ(boost_graph[1].region_id, 1u);
+	ASSERT_DOUBLE_EQ(boost_graph[1].passenger_fraction, 0.01);
+
+	boost::property_map<BoostGraph, boost::edge_weight_t>::type edge_weight_map =
+	    get(boost::edge_weight_t(), boost_graph);
+	std::pair<BoostGraph::edge_descriptor, bool> route1 = boost::edge(0, 1, boost_graph);
+	std::pair<BoostGraph::edge_descriptor, bool> route2 = boost::edge(1, 0, boost_graph);
+
+	ASSERT_TRUE(route1.second);
+	ASSERT_TRUE(route2.second);
+	ASSERT_DOUBLE_EQ(edge_weight_map[route1.first], 2.0);
+	ASSERT_DOUBLE_EQ(edge_weight_map[route2.first], 1.0);
+}
+
+} // Tests


### PR DESCRIPTION
This PR defines `RegionTravel::ToBoostGraph()`, which converts a `RegionTravel` to a `boost::adjacency_list<boost::vecS, boost::vecS, boost::directedS, AirportDescription, boost::property<boost::edge_weight_t, double>>`. There's also a unit test in there somewhere that verifies the accuracy of the translation from our model to a boost graph.

I couldn't implement the inverse transformation because `ToBoostGraph()` is lossy: our model includes region information (such as population file paths) that cannot easily/sensibly be converted to a graph.

In addition to this, I have also implemented ID recycling in the simulator plus some miscellaneous optimizations.