### PR TITLE
Change our performance measurements

### DIFF
--- a/src/doc/latex_user_man/04-Parallelization.tex
+++ b/src/doc/latex_user_man/04-Parallelization.tex
@@ -44,21 +44,23 @@ OpenMP, TBB and our custom implementation based on standard library threads are 
 
 Figure \ref{fig:parallelization-mean-runtimes} shows the mean run-times of the \texttt{run\_popgen\_small.xml}, \texttt{run\_popgen\_medium.xml} and \texttt{run\_popgen\_large.xml} configurations for each parallelization library. These configurations generate a population and then run the simulator on the generated population for one hundred days. They are identical in every way except for the size of the population that is generated.
 
-Each configuration was run ten times per parallelization library. Mean run-times are represented in figure \ref{fig:parallelization-mean-runtimes}. The relative standard deviation for each cell in the table is less than four percent. The measurements were produced by an Intel Core i7-6700K CPU running Ubuntu 17.04, gcc 6.3.0 and TBB 4.4.
+Each configuration was run ten times per parallelization library. Only the wall-clock time of the simulation itself was measured; population generation times were excluded because population generation is not parallelized---including it would unfairly slant the results in favor of the no-parallelization implementation.
+
+Mean run-times are represented in figure \ref{fig:parallelization-mean-runtimes}. The relative standard deviation for each cell in the table is less than five percent. The measurements were produced by an Intel Core i7-6700K CPU running Ubuntu 17.04, gcc 6.3.0 and TBB 4.4.
 
 \begin{figure}[h]
 	\begin{tabular}{r|r|r|r|r}
 		\textbf{Population size} & \textbf{OpenMP} & \textbf{TBB} & \textbf{STL} & \textbf{none} \\
-		100,000 & 6.00s & 6.09s & 5.80s & 6.69s \\
-		500,000 & 53.01s & 53.34s & 52.08s & 57.97s \\
-		1,000,000 & 169.69s & 166.81s & 167.91s & 178.97s
+		100,000 & 6.59s & 8.17s & 7.31s & 8.41s \\
+		500,000 & 34.53s & 42.92s & 38.12s & 45.75s \\
+		1,000,000 & 71.32s & 83.42s & 77.94s & 95.40s
 	\end{tabular}
 	\label{fig:parallelization-mean-runtimes}
-	\caption{Mean run-times for each parallelization library.}
+	\caption{Mean run-times for each parallelization library}
 \end{figure}
 
 What stands out from this table is that our standard library threads--based implementation is competitive with OpenMP and TBB performance-wise, despite using a na\"ive static partitioning scheme.
 
 This can likely be attributed to the homogeneity of the workloads that are parallelized: at the time of writing, parallelization functions are used in such a way that arbitrarily chosen but equally-sized chunks of items to process take roughly the same amount of time to process.
 
-OpenMP and TBB have much more intelligent schedulers than our simple standard library threads--based implementation, but it's hard for them to outperform our simple static scheduler because its behavior is optimal for homogeneous workloads, which the workloads offered by Stride approximate well.
+OpenMP and TBB have much more intelligent schedulers than our simple standard library threads--based implementation, but it's hard for them to outperform our simple static scheduler because its behavior is optimal for homogeneous workloads, which the workloads offered by Stride approximate well. As a matter of fact, our simple STL implementation outperforms the TBB implementation on all workloads and is second only to the OpenMP implementation performance-wise.

--- a/src/main/cpp/sim/run_stride.cpp
+++ b/src/main/cpp/sim/run_stride.cpp
@@ -208,16 +208,17 @@ void run_stride(const MultiSimulationConfig& config)
 		    std::numeric_limits<size_t>::max());
 		file_logger->set_pattern("%v"); // Remove meta data from log => time-stamp of logging
 
-		tasks.push_back(
-		    {log_name, sim_output_prefix, single_config,
-		     sim_manager.CreateSimulation(single_config, file_logger, region_id)});
+		tasks.push_back({log_name, sim_output_prefix, single_config,
+				 sim_manager.CreateSimulation(single_config, file_logger, region_id)});
 	}
 	cout << "Done building simulators. " << endl << endl;
 
 	// -----------------------------------------------------------------------------------------
 	// Run the simulation.
 	// -----------------------------------------------------------------------------------------
+	Stopwatch<> sim_clock("sim_clock", true);
 	sim_manager.WaitAll();
+	sim_clock.Stop();
 
 	// Generate output files for the simulations.
 	for (const auto& sim_tuple : tasks) {
@@ -250,9 +251,7 @@ void run_stride(const MultiSimulationConfig& config)
 			vis_file.Print(pop->GetAtlas().getTownMap(), sim_result.visualizer_data);
 		}
 
-		cout << endl << endl;
-		cout << "  run_time: " << sim_result.GetRuntimeString() << "  -- total time: " << total_clock.ToString()
-		     << endl
+		cout << "simulator #" << sim_result.id << " is done; simulation time: " << sim_result.GetRuntimeString()
 		     << endl;
 
 		spdlog::drop(sim_tuple.log_name);
@@ -261,7 +260,11 @@ void run_stride(const MultiSimulationConfig& config)
 	// -----------------------------------------------------------------------------------------
 	// Print final message to command line.
 	// -----------------------------------------------------------------------------------------
-	cout << "Exiting at:         " << TimeStamp().ToString() << endl << endl;
+	cout << endl << endl;
+	cout << "total time: " << total_clock.ToString() << endl
+	     << "total simulation time: " << sim_clock.ToString() << endl
+	     << "Exiting at: " << TimeStamp().ToString() << endl
+	     << endl;
 }
 
 /// Run the stride simulator.

--- a/src/main/resources/python/aggregate_time_measurements.py
+++ b/src/main/resources/python/aggregate_time_measurements.py
@@ -1,14 +1,42 @@
 from __future__ import division
 
+
 def compute_stats(data):
     stats = []
     for test_name, measurements in data.items():
         mean = sum(measurements) / len(measurements)
-        stddev = (sum(map(lambda x: (x - mean) ** 2, measurements)) / (len(measurements) - 1)) ** 0.5
+        stddev = (sum(map(lambda x: (x - mean)**2, measurements)) /
+                  (len(measurements) - 1))**0.5
         stats.append('%s mean: %.2f' % (test_name, mean))
         stats.append('%s standard deviation: %.2f' % (test_name, stddev))
-        stats.append('%s relative standard deviation: %.2f' % (test_name, stddev / mean))
+        stats.append('%s relative standard deviation: %.2f' %
+                     (test_name, stddev / mean))
     return stats
+
+
+def hours_to_minutes(hours):
+    return hours * 60
+
+
+def minutes_to_seconds(minutes):
+    return minutes * 60
+
+
+def hours_to_seconds(hours):
+    return minutes_to_seconds(hours_to_minutes(hours))
+
+
+def milliseconds_to_seconds(milliseconds):
+    return milliseconds / 1000
+
+
+def microseconds_to_milliseconds(microseconds):
+    return microseconds / 1000
+
+
+def microseconds_to_seconds(microseconds):
+    return milliseconds_to_seconds(microseconds_to_milliseconds(microseconds))
+
 
 def lines_to_data(lines):
     results = {}
@@ -18,8 +46,19 @@ def lines_to_data(lines):
             test_name = line[1:].strip()
             results[test_name] = []
         else:
-            results[test_name].append(float(line.strip()))
+            # stride formats timing data as hours:minutes:seconds:milliseconds:microseconds
+            split_data = line.strip().split(':')
+            assert (len(split_data) == 5)
+            elapsed_secs = \
+                hours_to_seconds(float(split_data[0])) + \
+                minutes_to_seconds(float(split_data[1])) + \
+                float(split_data[2]) + \
+                milliseconds_to_seconds(float(split_data[3])) + \
+                microseconds_to_seconds(float(split_data[4]))
+
+            results[test_name].append(elapsed_secs)
     return results
+
 
 if __name__ == "__main__":
     with open('measurements.txt') as f:

--- a/src/main/resources/python/aggregate_time_measurements.py
+++ b/src/main/resources/python/aggregate_time_measurements.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from collections import OrderedDict
 
 
 def compute_stats(data):
@@ -39,7 +40,7 @@ def microseconds_to_seconds(microseconds):
 
 
 def lines_to_data(lines):
-    results = {}
+    results = OrderedDict()
     test_name = ""
     for line in lines:
         if line.startswith('#'):

--- a/src/main/resources/sh/time_parallelization.sh
+++ b/src/main/resources/sh/time_parallelization.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+function run-and-time {
+    ./bin/stride -c $1 | grep "total simulation time:" | grep -o "0.*"
+}
+
 make clean
 export STRIDE_PARALLELIZATION_LIBRARY=OpenMP
 make
@@ -8,17 +12,17 @@ pushd build/installed
 echo "# small-openmp" > ../../measurements.txt
 for i in `seq 1 10`;
 do
-    { /usr/bin/time -f %e --quiet ./bin/stride -c config/run_popgen_small.xml; } 2>> ../../measurements.txt
+    run-and-time config/run_popgen_small.xml >> ../../measurements.txt
 done
 echo "# medium-openmp" >> ../../measurements.txt
 for i in `seq 1 10`;
 do
-    { /usr/bin/time -f %e --quiet ./bin/stride -c config/run_popgen_medium.xml; } 2>> ../../measurements.txt
+    run-and-time config/run_popgen_medium.xml >> ../../measurements.txt
 done
 echo "# large-openmp" >> ../../measurements.txt
 for i in `seq 1 10`;
 do
-    { /usr/bin/time -f %e --quiet ./bin/stride -c config/run_popgen_large.xml; } 2>> ../../measurements.txt
+    run-and-time config/run_popgen_large.xml >> ../../measurements.txt
 done
 popd
 
@@ -30,17 +34,17 @@ pushd build/installed
 echo "# small-tbb" >> ../../measurements.txt
 for i in `seq 1 10`;
 do
-    { /usr/bin/time -f %e --quiet ./bin/stride -c config/run_popgen_small.xml; } 2>> ../../measurements.txt
+    run-and-time config/run_popgen_small.xml >> ../../measurements.txt
 done
 echo "# medium-tbb" >> ../../measurements.txt
 for i in `seq 1 10`;
 do
-    { /usr/bin/time -f %e --quiet ./bin/stride -c config/run_popgen_medium.xml; } 2>> ../../measurements.txt
+    run-and-time config/run_popgen_medium.xml >> ../../measurements.txt
 done
 echo "# large-tbb" >> ../../measurements.txt
 for i in `seq 1 10`;
 do
-    { /usr/bin/time -f %e --quiet ./bin/stride -c config/run_popgen_large.xml; } 2>> ../../measurements.txt
+    run-and-time config/run_popgen_large.xml >> ../../measurements.txt
 done
 popd
 
@@ -52,17 +56,17 @@ pushd build/installed
 echo "# small-stl" >> ../../measurements.txt
 for i in `seq 1 10`;
 do
-    { /usr/bin/time -f %e --quiet ./bin/stride -c config/run_popgen_small.xml; } 2>> ../../measurements.txt
+    run-and-time config/run_popgen_small.xml >> ../../measurements.txt
 done
 echo "# medium-stl" >> ../../measurements.txt
 for i in `seq 1 10`;
 do
-    { /usr/bin/time -f %e --quiet ./bin/stride -c config/run_popgen_medium.xml; } 2>> ../../measurements.txt
+    run-and-time config/run_popgen_medium.xml >> ../../measurements.txt
 done
 echo "# large-stl" >> ../../measurements.txt
 for i in `seq 1 10`;
 do
-    { /usr/bin/time -f %e --quiet ./bin/stride -c config/run_popgen_large.xml; } 2>> ../../measurements.txt
+    run-and-time config/run_popgen_large.xml >> ../../measurements.txt
 done
 popd
 
@@ -74,16 +78,16 @@ pushd build/installed
 echo "# small-none" >> ../../measurements.txt
 for i in `seq 1 10`;
 do
-    { /usr/bin/time -f %e --quiet ./bin/stride -c config/run_popgen_small.xml; } 2>> ../../measurements.txt
+    run-and-time config/run_popgen_small.xml >> ../../measurements.txt
 done
 echo "# medium-none" >> ../../measurements.txt
 for i in `seq 1 10`;
 do
-    { /usr/bin/time -f %e --quiet ./bin/stride -c config/run_popgen_medium.xml; } 2>> ../../measurements.txt
+    run-and-time config/run_popgen_medium.xml >> ../../measurements.txt
 done
 echo "# large-none" >> ../../measurements.txt
 for i in `seq 1 10`;
 do
-    { /usr/bin/time -f %e --quiet ./bin/stride -c config/run_popgen_large.xml; } 2>> ../../measurements.txt
+    run-and-time config/run_popgen_large.xml >> ../../measurements.txt
 done
 popd


### PR DESCRIPTION
Howdy partners.

This PR changes our performance measurement methodology: it measures simulation times only instead of population generation times + simulation times + stride cruft times. (Professor Broeckhove suggested this change during our beta presentation.)

The numbers in the performance comparison table of our user manual's parallelization chapter have changed, though the overall picture painted by that table remains unchanged&mdash;parallelization results in a modest speedup at best. On the plus side, the difference in terms of performance between the OpenMP, TBB and STL implementations is clearer now. Turns out that our homebrew STL implementation is actually *better* than the TBB implementation. :tada:

I've also taken the liberty to change the formatting of the (timing) information printed in `run_stride.cpp`. Users should have a better idea of what's going on now.